### PR TITLE
Remove psycopg2 from requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ Sphinx
 coverage
 hurry.filesize
 pep8
-psycopg2
 pyflakes
 python-coveralls
 python-dateutil


### PR DESCRIPTION
This was put in there way back when, but we're running the app on MySQL
instead of postgres, and so removing it will simplify the install
instructions by not requiring `pip install` to compile native extensions
that depend on the postgres source code.

@lukehtravis hit this as he was setting up the repo.
