### PR TITLE
Write netfile CSVs as utf-8

### DIFF
--- a/netfile/connect2_api.py
+++ b/netfile/connect2_api.py
@@ -28,7 +28,6 @@ def paginated_query(func):
 
         pages = response.json()['totalMatchingPages']
         logger.info("Fetching page %d of %d pages available" % (page_index, pages))
-        pages = min(pages, 2) #TODO Once the queries are set, unlimit this. For now, limit to two pages of data
 
         results = response.json()['results']
         while True:


### PR DESCRIPTION
Un-limits the number of pages (per agency) we're fetching from Netfile. Still hardcoded the date. This addresses the encoding issues, dumps to CSVs in `./netfile_raw_data`.
