### PR TITLE
Add initial API endpoints for contributions

### DIFF
--- a/disclosure-backend/project/serializers.py
+++ b/disclosure-backend/project/serializers.py
@@ -1,0 +1,7 @@
+from calaccess_raw.models.campaign import RcptCd
+from rest_framework import serializers
+
+
+class ContributionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RcptCd

--- a/disclosure-backend/project/settings.py
+++ b/disclosure-backend/project/settings.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = (
     'ballot',
     'netfile',
     'zipcode_metro',
+    'rest_framework_swagger'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/disclosure-backend/project/urls.py
+++ b/disclosure-backend/project/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.contrib import admin
+from rest_framework.routers import SimpleRouter
 
 import views
 
@@ -13,4 +14,10 @@ urlpatterns = patterns('',
         'document_root': settings.STATIC_ROOT,
         'show_indexes': True,
     }),
+    url(r'^docs/', include('rest_framework_swagger.urls'))
 )
+
+# Register all API Viewsets:
+api = SimpleRouter()
+api.register(r'contributions', views.Contribution)
+urlpatterns += api.urls

--- a/disclosure-backend/project/views.py
+++ b/disclosure-backend/project/views.py
@@ -1,4 +1,37 @@
+from calaccess_raw.models.campaign import RcptCd
 from django.http import HttpResponse
+from serializers import ContributionSerializer
+from rest_framework import viewsets
+from rest_framework.response import Response
+from rest_framework.renderers import JSONRenderer
+
+
+class Contribution(viewsets.ViewSet):
+    """
+    A contribution is money that an filing committee has received.
+    ---
+    retrieve:
+      response_serializer: ContributionSerializer
+      parameters:
+        - name: id
+          required: true
+          paramType: query
+    list:
+      response_serializer: ContributionSerializer
+    """
+    renderer_classes = [JSONRenderer]
+    queryset = RcptCd.objects.all()
+
+    def list(self, request):
+        """ List all contributions """
+        obj = RcptCd.objects.all()[1:10]
+        return Response(ContributionSerializer(obj, many=True).data)
+
+    def retrieve(self, request, format=None):
+        """ Get a single contribution """
+        obj = RcptCd.objects.get(id=request.GET['id'])
+        return Response(ContributionSerializer(obj).data)
+
 
 def homepage_view(request):
-    return HttpResponse("Hello!")
+    return HttpResponse("<a href='/docs/'>Check out the API Documentation</a>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 mysqlclient
 Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@dab635c6c242b11c81add0069c7d9ee1c842e866#egg=swaggerpy-master
+django-rest-swagger


### PR DESCRIPTION
This is mostly a proof of concept for how to mash together the Django
REST framework with the Django REST swagger auto-documentation. But it
should work!

Obviously, there is a lot of work to do to make these API endpoints do
the right thing.
