### PR TITLE
Added year 2015 to netfile agency data import

### DIFF
--- a/netfile/management/commands/downloadnetfilerawdata.py
+++ b/netfile/management/commands/downloadnetfilerawdata.py
@@ -135,7 +135,7 @@ class Command(loadcalaccessrawfile.Command):
 
         for agency in agencies:
 
-            for year in ['2014']:
+            for year in ['2014','2015']:
                 csv_path = 'netfile_%s_%s_cal201_export.csv' % (year, agency['shortcut'])
                 transactions = self.fetch_transactions_agency_year(agency, year)
                 self._write_csv(csv_path, transactions)


### PR DESCRIPTION
Right now `downloadnetfilerawdata.py` is only importing 2014 data for local (county, city) agencies.  If this gits merged then we'll be downloading 2015 data as well.  What say ye?
