### PR TITLE
Fix netfile_agency table to contain correct rows

### DIFF
--- a/netfile/management/commands/downloadnetfilerawdata.py
+++ b/netfile/management/commands/downloadnetfilerawdata.py
@@ -166,7 +166,7 @@ class Command(loadcalaccessrawfile.Command):
 
         with open(os.path.join(self.data_dir, csv_path), 'w') as csv_handle:
             headers = item.keys()
-            writer = UnicodeDictWriter(csv_handle, headers)
+            writer = UnicodeDictWriter(csv_handle, headers, lineterminator='\n')
             writer.writeheader()
             writer.writerow(item)
             for item in iterator:


### PR DESCRIPTION
Previously, importing the data would result in two rows due to the
line terminators being expected to be '\n' [here](https://github.com/california-civic-data-coalition/django-calaccess-raw-data/blob/3f74dad85/calaccess_raw/management/commands/loadcalaccessrawfile.py#L107). Since that query
is too difficult to change, it's easier to just output the file without
'\r' line endings.
