### PR TITLE
Location fips

### DIFF
--- a/disclosure_backend/project/urls.py
+++ b/disclosure_backend/project/urls.py
@@ -16,7 +16,7 @@ urlpatterns = patterns('',
         'show_indexes': True,
     }),
     url(r'^search/', views.search_view),
-    url(r'^locations/(?P<fip_id>.*)', views.location_view),
+    url(r'^locations/(?P<fips_id>[0-9]+)$', views.location_view),
     url(r'^docs/', include('rest_framework_swagger.urls'))
 )
 

--- a/disclosure_backend/project/views.py
+++ b/disclosure_backend/project/views.py
@@ -31,14 +31,17 @@ class Contribution(viewsets.ViewSet):
 
 
 @api_view(['GET'])
-def location_view(request, fip_id=None):
+def location_view(request, fips_id):
     """
     Display summarized information about a location
     NOTE: This is stubbed to always return the same thing.
     ---
     parameters:
-      - name: fip_id
-        type: string
+      - name: fips_id
+        description: The Federal Information Processing Standards (FIPS) code for this locality.
+        paramType: path
+        type: integer
+        required: true
     response_serializer: LocationSerializer
     """
     return Response({

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Django==1.8
 -e git://github.com/caciviclab/django-calaccess-raw-data.git@0dd6b6913e4a00b49d1b9c9bf9829ed83f4587a3#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0


### PR DESCRIPTION
cc @tdooner 

The yaml docstring takes precedence over the view introspection, so swagger was getting confused, thinking the path was literally `/locations/{fips_id}` with an additional `fip_id` form parameter (which doesn't make any sense because it's a GET). Anyway, double check the docstring if you find yourself banging your head against the wall like I was.
