### PR TITLE
Set self.app_name instead of using customized codepath.

### DIFF
--- a/netfile/management/commands/downloadnetfilerawdata.py
+++ b/netfile/management/commands/downloadnetfilerawdata.py
@@ -80,6 +80,7 @@ class UnicodeDictWriter(object):
 
 class Command(loadcalaccessrawfile.Command):
     help = 'Download and load the Netfile raw data'
+    app_name = 'netfile'
     option_list = loadcalaccessrawfile.Command.option_list + custom_options
     # netfile gives us ISO8601 formatted dates, so we have to override the
     # calaccess_raw date hack with a slightly different one :)
@@ -144,12 +145,12 @@ class Command(loadcalaccessrawfile.Command):
     def load(self):
         if self.verbosity:
             self.header("Loading Agency CSV file")
-        super(Command, self).load('NetFileAgency', app='netfile')
+        super(Command, self).load('NetFileAgency')
         if self.verbosity:
             self.success("ok.")
         if self.verbosity:
             self.header("Loading Cal201 Transaction Data")
-        super(Command, self).load('NetFileCal201Transaction', app='netfile')
+        super(Command, self).load('NetFileCal201Transaction')
         if self.verbosity:
             self.success("ok.")
 

--- a/zipcode_metro/management/commands/downloadzipcodedata.py
+++ b/zipcode_metro/management/commands/downloadzipcodedata.py
@@ -32,6 +32,7 @@ custom_options = (
 
 class Command(loadcalaccessrawfile.Command):
     help = 'Download and load the Zipcode raw data'
+    app_name = 'zipcode_metro'
     url = "https://s3-us-west-1.amazonaws.com/zipcodemetro/zipcode_metro.csv.zip"
     option_list = loadcalaccessrawfile.Command.option_list + custom_options
 
@@ -70,6 +71,6 @@ class Command(loadcalaccessrawfile.Command):
     def load(self):
         if self.verbosity:
             self.header("Loading CSV files")
-        super(Command, self).load('ZipCodeMetro', app='zipcode_metro')
+        super(Command, self).load('ZipCodeMetro')
         if self.verbosity:
             self.success('ok.')


### PR DESCRIPTION
https://github.com/caciviclab/django-calaccess-raw-data/commit/0dd6b6913e4a00b49d1b9c9bf9829ed83f4587a3 diverges this codebase from the fork, but the fork already has a mechanism for specifying an app for loading models from: simply set `self.app_name`.

If merged, and https://github.com/california-civic-data-coalition/django-calaccess-raw-data/pull/1151 is accepted, I think the entire https://github.com/caciviclab/django-calaccess-raw-data/ repo can be eliminated.
