### PR TITLE
BF: #15 remove dependency on our own fork of calaccess_raw

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
--e git://github.com/caciviclab/django-calaccess-raw-data.git@0dd6b6913e4a00b49d1b9c9bf9829ed83f4587a3#egg=django-calaccess-raw-data
+-e git://github.com/california-civic-data-coalition/django-calaccess-raw-data.git#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@4edd44884c56c8ac41e91c6505e8ace734bd6b75#egg=swaggerpy-master


### PR DESCRIPTION
Title says it all. Just a small change to `requirements.txt`, verified by installing on a clean virtualenv, then running `make test`.
