### PR TITLE
Migrate Contest.contest_type field options

### DIFF
--- a/ballot/migrations/0004_auto_20160106_1641.py
+++ b/ballot/migrations/0004_auto_20160106_1641.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ballot', '0003_auto_20151219_0359'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contest',
+            name='contest_type',
+            field=models.CharField(help_text=b'Office if the contest is for a person, referendum if the contest is for an issue.', max_length=1, choices=[(b'R', b'Referendum'), (b'O', b'Office')]),
+        ),
+    ]


### PR DESCRIPTION
Missing migration. Fixes #114.
