### PR TITLE
Move data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.pyc
 
 # Data
-disclosure_backend/data/
-disclosure_backend/test-data/csv
+data/
 
 # Django
 settings_local.py

--- a/disclosure_backend/settings.py
+++ b/disclosure_backend/settings.py
@@ -1,7 +1,8 @@
 import os
+import os.path as op
 
-BASE_DIR = os.path.dirname(__file__)
-REPO_DIR = os.path.join(BASE_DIR, os.pardir)
+BASE_DIR = op.dirname(__file__)
+REPO_DIR = op.join(BASE_DIR, os.pardir)
 SECRET_KEY = 'w11nbg_3n4+e@qk^b55qgo5qygesn^3=&s1kwtlbpkai$(1jv3'
 DEBUG = True
 TEMPLATE_DEBUG = True
@@ -9,18 +10,19 @@ ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
 ]
-STATIC_ROOT = os.path.join(BASE_DIR, ".static")
+STATIC_ROOT = op.join(BASE_DIR, ".static")
 
 try:
     # Set CALACCESS_TEST_DOWNLOAD_DIR for testing calaccess data commands.
     import calaccess_raw
-    _calaccess_repo_dir = os.path.join(os.path.dirname(calaccess_raw.__file__),
-                                       os.pardir)
-    CALACCESS_TEST_DOWNLOAD_DIR = os.path.join(_calaccess_repo_dir,
-                                               'example', 'test-data')
+    _calaccess_repo_dir = op.join(op.dirname(calaccess_raw.__file__),
+                                  os.pardir)
+    CALACCESS_TEST_DOWNLOAD_DIR = op.join(_calaccess_repo_dir,
+                                          'example', 'test-data')
 except:
     pass
 
+CALACCESS_DOWNLOAD_DIR = op.join(REPO_DIR, 'data', 'calaccess')
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',

--- a/disclosure_backend/settings.py
+++ b/disclosure_backend/settings.py
@@ -23,6 +23,9 @@ except:
     pass
 
 CALACCESS_DOWNLOAD_DIR = op.join(REPO_DIR, 'data', 'calaccess')
+NETFILE_DOWNLOAD_DIR = op.join(REPO_DIR, 'data', 'netfile')
+
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',

--- a/netfile/management/commands/downloadnetfilerawdata.py
+++ b/netfile/management/commands/downloadnetfilerawdata.py
@@ -10,9 +10,10 @@ import codecs
 import glob
 import warnings
 
-from calaccess_raw import get_download_directory
+import calaccess_raw
 from calaccess_raw.management.commands import loadcalaccessrawfile
 from django.db import connection
+from django.conf import settings
 from optparse import make_option
 
 from netfile.connect2_api import Connect2API
@@ -70,6 +71,28 @@ custom_options = (
         help="Skip loading up the raw data files"
     ),
 )
+
+
+def get_download_directory():
+    """
+    Returns the download directory where we will store downloaded data.
+    """
+    if hasattr(settings, 'NETFILE_DOWNLOAD_DIR'):
+        return getattr(settings, 'NETFILE_DOWNLOAD_DIR')
+    else:
+        return calaccess_raw.get_download_directory()
+
+
+def get_test_download_directory():
+    """
+    Returns the download directory where we will store test data.
+    """
+    if hasattr(settings, 'CALACCESS_TEST_DOWNLOAD_DIR'):
+        return getattr(settings, 'CALACCESS_TEST_DOWNLOAD_DIR')
+    elif hasattr(settings, 'BASE_DIR'):
+        return os.path.join(getattr(settings, 'BASE_DIR'), 'test-data')
+    raise ValueError("CAL-ACCESS test download directory not configured. \
+Set either CALACCESS_TEST_DOWNLOAD_DIR or BASE_DIR in settings.py")
 
 
 class UnicodeDictWriter(object):


### PR DESCRIPTION
Rather than store data inside `/disclosure_backend/data/` (with no options), each app should store its data according to a setting (like `calaccess_raw` does). This PR:
- Makes `netfile_raw` read a setting for storage location, and falls back to the current `CALACCESS_RAW_DOWNLOAD_DIR`.
- Overrides the default values for these settings, and pushes data into a common `/data` location, so that when we refactor apps, the data isn't moved around / lost.
