### PR TITLE
ENH: just set password in settings_local.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,7 @@ We're going to create an environment with Python 2.7.9 for the project
 2. Create `disclosure/settings_local.py`
 
   ```
-  DATABASES = {
-    'default': {
-        'NAME': 'calaccess_raw',
-        'PASSWORD': '',
-        'ENGINE': 'django.db.backends.mysql',
-        'USER': 'root',
-        'HOST': 'localhost',
-        'PORT': '3306',
-        'OPTIONS': {
-            'local_infile': 1,
-        }
-    }
-  }
+  DATABASES['default']['PASSWORD'] = ''
   ```
 
   Change the password field to the password you chose when you installed MySQL.

--- a/disclosure/settings.py
+++ b/disclosure/settings.py
@@ -82,6 +82,8 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 try:
-    from .settings_local import *  # noqa
-except ImportError:
+    script_dir = os.path.dirname(__file__)
+    with open(os.path.join(script_dir, 'settings_local.py')) as fp:
+        exec(fp.read())
+except:
     pass


### PR DESCRIPTION
Currently, `settings_local` must redefine the entire database block just to set the password. That's crazy. This PR makes it much simpler, and allows `settings_local.py` to run arbitrary code, rather than just setting variables.
