### PR TITLE
ENH: lazy connect to netfile API.

### DIFF
--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -160,7 +160,6 @@ class Command(loadcalaccessrawfile.Command):
         self.data_dir = os.path.join(get_download_directory(), 'csv')
         self.combined_csv_path = os.path.join(
             self.data_dir, 'netfile_cal201_transaction.csv')
-        self.connect2 = Connect2API()
 
         # Run the thing!
         if not options['skip_download']:
@@ -277,6 +276,13 @@ class Command(loadcalaccessrawfile.Command):
             if self.verbosity:
                 self.success('OK')
 
+    @property
+    def connect2(self):
+        """ Connecting to netfile is slow, so only do it on demand."""
+        if getattr(self, '_connect2', None) is None:
+            self._connect2 = Connect2API()
+        return self._connect2
+
     def fetch_transactions_agency_year(self, agency, year):
         # Break this up by transaction type?
         query = {
@@ -290,7 +296,19 @@ class Command(loadcalaccessrawfile.Command):
 
     def fetch_agencies(self):
         """Fetches agencies from Netfile API"""
-        agencies = self.connect2.getpubliccampaignagencies()
-        print "Found %s agencies" % (len(agencies))
-        self._write_csv('netfile_agency.csv', iter(agencies))
+        agency_csv_path = op.join(self.data_dir, 'netfile_agency.csv')
+        agencies = None
+        if not self.force and op.exists(agency_csv_path):
+            import pandas as pd
+            try:
+                agencies = pd.read_csv(agency_csv_path)
+                agencies = agencies.T.to_dict().values()
+            except:
+                os.remove(agency_csv_path)
+
+        if agencies is None:
+            agencies = self.connect2.getpubliccampaignagencies()
+            self._write_csv(agency_csv_path, iter(agencies))
+
+        print("Found %s agencies" % (len(agencies)))
         return agencies

--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -203,8 +203,9 @@ class Command(loadcalaccessrawfile.Command):
                 ','.join(years_not_found)))
             self.years = list(set(self.years) - years_not_found)
 
-        print("Downloading data for %d agencies in years %s" % (
-            len(agencies), ','.join(self.years)))
+        if self.verbosity:
+            print("Downloading data for %d agencies in years %s" % (
+                len(agencies), ','.join(self.years)))
         self.csv_paths = []
         for agency in agencies:
             for year in self.years:
@@ -219,6 +220,9 @@ class Command(loadcalaccessrawfile.Command):
                 self.csv_paths.append(csv_path)
 
     def combine(self):
+        if self.verbosity:
+            self.header("Combining %s csv files." % len(self.csv_paths))
+
         headers_written = False
         with file(self.combined_csv_path, 'w') as combined_csv:
             for path in self.csv_paths:
@@ -310,5 +314,6 @@ class Command(loadcalaccessrawfile.Command):
             agencies = self.connect2.getpubliccampaignagencies()
             self._write_csv(agency_csv_path, iter(agencies))
 
-        print("Found %s agencies" % (len(agencies)))
+        if self.verbosity:
+            print("Found %s agencies" % (len(agencies)))
         return agencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@4edd44884c56c8ac41e91c6505e8ace734bd6b75#egg=swaggerpy-master
 django-rest-swagger
 django-cors-headers==1.1.0
+pandas


### PR DESCRIPTION
To speed up testing during development, we already reuse cached netfile data downloads. Two things still slow down development:
1. We always download the netfile agency list, even if we already have it.
2. We connect to netfile every time, even if no downloads are needed.

With this PR, overhead before testing netfile data upload goes from ~8 seconds to less than 1 second.
