### PR TITLE
ENH: use multiple databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/data
+    - $HOME/disclosure-backend/data
 
 python:
  - "2.7"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ We're going to create an environment with Python 2.7.9 for the project
 1. Create the database
   ```
   mysql -p --user root
+  mysql> create database opendisclosure;
   mysql> create database calaccess_raw;
   mysql> \q
   ```
@@ -80,7 +81,8 @@ We're going to create an environment with Python 2.7.9 for the project
 2. Create `disclosure/settings_local.py`
 
   ```
-  DATABASES['default']['PASSWORD'] = ''
+  DATABASES['default']['PASSWORD'] = ''  # replace with your password.
+  DATABASES['calaccess_raw']['PASSWORD'] = ''  # replace with your password.
   ```
 
   Change the password field to the password you chose when you installed MySQL.
@@ -89,6 +91,7 @@ We're going to create an environment with Python 2.7.9 for the project
 3. Run the database migration scripts
   ```
   python manage.py migrate
+  python manage.py migrate --database calaccess_raw
   ```
 
   OSX: If you get the following error `django.core.exceptions.ImproperlyConfigured: Error loading MySQLdb module: dlopen(_mysql.so, 2): Library not loaded: libssl.1.0.0.dylib`

--- a/disclosure/admin.py
+++ b/disclosure/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.db import router
+
+for model in admin.site._registry.keys():
+    if router.db_for_write(model=model) != 'default':
+        admin.site.unregister(model)

--- a/disclosure/routers.py
+++ b/disclosure/routers.py
@@ -1,0 +1,39 @@
+class DisclosureRouter(object):
+    """
+    Allow calaccess_raw and netfile_raw to talk
+    to their own databases, separately from the
+    main app.
+    """
+    def get_db(self, model=None, app_label=None):
+        app_label = app_label or model._meta.app_label
+        if app_label.endswith('_raw'):
+            db_label = 'calaccess_raw'
+        else:
+            db_label = 'default'
+        return db_label
+
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read auth models go to auth_db.
+        """
+        return self.get_db(model=model)
+
+    def db_for_write(self, model, **hints):
+        """
+        Attempts to write auth models go to auth_db.
+        """
+        return self.get_db(model=model)
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations if a model in the auth app is involved.
+        """
+        return self.get_db(model=obj1) == self.get_db(model=obj2)
+
+    def allow_migrate(self, db, app_label, model=None, **hints):
+        """
+        Make sure the auth app only appears in the 'auth_db'
+        database.
+        """
+        intended_db = self.get_db(app_label=app_label)
+        return (db == intended_db) or (db == 'default' and intended_db is None)

--- a/disclosure/settings.py
+++ b/disclosure/settings.py
@@ -62,6 +62,17 @@ REST_FRAMEWORK = {
 
 DATABASES = {
     'default': {
+        'NAME': 'opendisclosure',
+        'PASSWORD': '',
+        'ENGINE': 'django.db.backends.mysql',
+        'USER': 'root',
+        'HOST': 'localhost',
+        'PORT': '3306',
+        'OPTIONS': {
+            'local_infile': 1,
+        },
+    },
+    'calaccess_raw': {
         'NAME': 'calaccess_raw',
         'PASSWORD': '',
         'ENGINE': 'django.db.backends.mysql',
@@ -70,9 +81,11 @@ DATABASES = {
         'PORT': '3306',
         'OPTIONS': {
             'local_infile': 1,
-        }
-    }
+        },
+    },
 }
+
+DATABASE_ROUTERS = ['disclosure.routers.DisclosureRouter']
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'

--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -11,7 +11,6 @@ import warnings
 
 import calaccess_raw
 from calaccess_raw.management.commands import loadcalaccessrawfile
-from django.db import connection
 from django.conf import settings
 from optparse import make_option
 
@@ -144,6 +143,7 @@ class Command(loadcalaccessrawfile.Command):
 
     def handle(self, *args, **options):
         # Parse command-line options
+        self.database = options['database']
         self.verbosity = int(options['verbosity'])
         self.max_lines_per_load = int(options['max_lines_per_load'])
         if options['agencies'] is None:
@@ -170,7 +170,6 @@ class Command(loadcalaccessrawfile.Command):
             self.combine()
 
         if not options['skip_load']:
-            self.cursor = connection.cursor()
             self.load()
 
     def download(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
--e git://github.com/bcipolli/django-calaccess-raw-data.git@160abedfd53ceb3ba671f8b6b24c690c212ff5c3#egg=django-calaccess-raw-data
+-e git://github.com/bcipolli/django-calaccess-raw-data.git@cd559899e783f6e754743713771d465d242807f2#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@4edd44884c56c8ac41e91c6505e8ace734bd6b75#egg=swaggerpy-master

--- a/zipcode_metro_raw/management/commands/downloadzipcodedata.py
+++ b/zipcode_metro_raw/management/commands/downloadzipcodedata.py
@@ -8,7 +8,6 @@ import zipfile
 
 from calaccess_raw import get_download_directory
 from calaccess_raw.management.commands import loadcalaccessrawfile
-from django.db import connection
 from optparse import make_option
 
 
@@ -38,6 +37,7 @@ class Command(loadcalaccessrawfile.Command):
     option_list = loadcalaccessrawfile.Command.option_list + custom_options
 
     def handle(self, *args, **options):
+        self.database = options['database']
         self.verbosity = int(options['verbosity'])
         self.max_lines_per_load = int(options.get('max_lines_per_load', 1000))
         self.data_dir = os.path.join(get_download_directory(), 'csv')
@@ -47,7 +47,6 @@ class Command(loadcalaccessrawfile.Command):
             self.download()
 
         if not options['skip_load']:
-            self.cursor = connection.cursor()
             self.load()
 
     def download(self):

--- a/zipcode_metro_raw/tests.py
+++ b/zipcode_metro_raw/tests.py
@@ -1,0 +1,27 @@
+import os.path as op
+import tempfile
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from zipcode_metro_raw.models import ZipCodeMetro
+
+
+@override_settings(CALACCESS_DOWNLOAD_DIR=tempfile.mkdtemp())
+class ZipcodeMetroTest(TestCase):
+
+    def test_download_agencies(self):
+        """
+        Tests a single file download
+        """
+
+        # Smoke test--make sure there are no errors.
+        call_command('downloadzipcodedata')
+
+        zipcodes_path = op.join(settings.CALACCESS_DOWNLOAD_DIR,
+                                'csv', 'zipcode_metro.csv')
+        self.assertTrue(op.exists(zipcodes_path), zipcodes_path)
+
+        # Check data
+        self.assertTrue(ZipCodeMetro.objects.all().count() > 0)


### PR DESCRIPTION
Currently, we're using the `calaccess_raw` database for all of our data. 
- This name isn't very meaningful. 
- It also means that management commands to clear the database clears both raw data and processed data.
- I'd suggest that loading the raw data into the database is really a dev step, not a production step.

This PR routes all raw data to a non-default `calaccess_raw` database. The default database, `opendisclosure`, is where all processed data lives.

Note that this requires slightly more setup (one extra line in `settings_local.py`, two extra commands at the command-line) If and when we stop storing raw data in the database (and I believe we will), we'll easily be able to drop the extra setup steps.

 Note that this PR depends on https://github.com/caciviclab/disclosure-backend/pull/119
