### PR TITLE
BF: #112: pass csv files directly to updated calaccess_raw.

### DIFF
--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -158,6 +158,7 @@ class Command(loadcalaccessrawfile.Command):
 
         # Compute properties
         self.data_dir = os.path.join(get_download_directory(), 'csv')
+        self.agency_csv_path = op.join(self.data_dir, 'netfile_agency.csv')
         self.combined_csv_path = os.path.join(
             self.data_dir, 'netfile_cal201_transaction.csv')
 
@@ -245,12 +246,14 @@ class Command(loadcalaccessrawfile.Command):
     def load(self):
         if self.verbosity:
             self.header("Loading Agency CSV file")
-        super(Command, self).load('NetFileAgency')
+        super(Command, self).load(
+            'NetFileAgency', csv_path=self.agency_csv_path)
         if self.verbosity:
             self.success("ok.")
         if self.verbosity:
             self.header("Loading Cal201 Transaction Data")
-        super(Command, self).load('NetFileCal201Transaction')
+        super(Command, self).load(
+            'NetFileCal201Transaction', csv_path=self.combined_csv_path)
         if self.verbosity:
             self.success("ok.")
 
@@ -300,19 +303,18 @@ class Command(loadcalaccessrawfile.Command):
 
     def fetch_agencies(self):
         """Fetches agencies from Netfile API"""
-        agency_csv_path = op.join(self.data_dir, 'netfile_agency.csv')
         agencies = None
-        if not self.force and op.exists(agency_csv_path):
+        if not self.force and op.exists(self.agency_csv_path):
             import pandas as pd
             try:
-                agencies = pd.read_csv(agency_csv_path)
+                agencies = pd.read_csv(self.agency_csv_path)
                 agencies = agencies.T.to_dict().values()
             except:
-                os.remove(agency_csv_path)
+                os.remove(self.agency_csv_path)
 
         if agencies is None:
             agencies = self.connect2.getpubliccampaignagencies()
-            self._write_csv(agency_csv_path, iter(agencies))
+            self._write_csv(self.agency_csv_path, iter(agencies))
 
         if self.verbosity:
             print("Found %s agencies" % (len(agencies)))

--- a/netfile_raw/tests.py
+++ b/netfile_raw/tests.py
@@ -1,13 +1,40 @@
-from django.test import TestCase
+import os.path as op
+import tempfile
 
-# from . import models
-from . import connect2_api
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from netfile_raw import connect2_api
+from netfile_raw.models import NetFileAgency, NetFileCal201Transaction
 
 
+@override_settings(NETFILE_DOWNLOAD_DIR=tempfile.mkdtemp())
 class NetfileTests(TestCase):
-
     def test_models_import_correctly(self):
         """
         Tests that the modules can be imported, (that's something).
         """
         self.assertIsNotNone(connect2_api)
+
+    def test_download_agencies(self, test_agency='CPA', test_year='2015'):
+        """
+        Tests a single file download
+        """
+
+        # Smoke test--make sure there are no errors.
+        call_command('downloadnetfilerawdata',
+                     agencies=test_agency, years=test_year)
+
+        agencies_path = op.join(settings.NETFILE_DOWNLOAD_DIR,
+                                'csv', 'netfile_agency.csv')
+        self.assertTrue(op.exists(agencies_path), agencies_path)
+
+        data_path = op.join(settings.NETFILE_DOWNLOAD_DIR,
+                            'csv', 'netfile_%s_%s_cal201_export.csv' % (
+                                test_year, test_agency))
+        self.assertTrue(op.exists(data_path), data_path)
+
+        # Check data
+        self.assertTrue(NetFileCal201Transaction.objects.all().count() > 0)
+        self.assertTrue(NetFileAgency.objects.all().count() > 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
--e git://github.com/california-civic-data-coalition/django-calaccess-raw-data.git#egg=django-calaccess-raw-data
+-e git://github.com/bcipolli/django-calaccess-raw-data.git@160abedfd53ceb3ba671f8b6b24c690c212ff5c3#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@4edd44884c56c8ac41e91c6505e8ace734bd6b75#egg=swaggerpy-master


### PR DESCRIPTION
This _finally_ fixes #112... and indicates the need for basic tests. So I added a simple netfile download/load test (one small file, plus netfile agencies) to avoid this issue in the future.

This has everything to do with #127 - out of sync with the `calaccess_raw` version we're all running. Temp fix is to refer to a commit in my repo. Will get a better fix when we start reviewing/merging PRs into our own `calaccess_raw` repo.
