### PR TITLE
Integrate with calaccess raw multi db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/data
+    - $HOME/disclosure-backend/data
 
 python:
  - "2.7"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build
 Status](https://travis-ci.org/caciviclab/disclosure-backend.svg?branch=master)](https://travis-ci.org/caciviclab/disclosure-backend)
+[![Coverage Status](https://coveralls.io/repos/caciviclab/disclosure-backend/badge.svg?branch=master&service=github)](https://coveralls.io/github/caciviclab/disclosure-backend?branch=master)
 
 California Civic Lab Disclosure Backend
 ==================================================

--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -11,7 +11,6 @@ import warnings
 
 import calaccess_raw
 from calaccess_raw.management.commands import loadcalaccessrawfile
-from django.db import connection
 from django.conf import settings
 from optparse import make_option
 
@@ -144,6 +143,7 @@ class Command(loadcalaccessrawfile.Command):
 
     def handle(self, *args, **options):
         # Parse command-line options
+        self.database = options['database']
         self.verbosity = int(options['verbosity'])
         self.max_lines_per_load = int(options['max_lines_per_load'])
         if options['agencies'] is None:
@@ -170,7 +170,6 @@ class Command(loadcalaccessrawfile.Command):
             self.combine()
 
         if not options['skip_load']:
-            self.cursor = connection.cursor()
             self.load()
 
     def download(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
--e git://github.com/bcipolli/django-calaccess-raw-data.git@160abedfd53ceb3ba671f8b6b24c690c212ff5c3#egg=django-calaccess-raw-data
+-e git://github.com/bcipolli/django-calaccess-raw-data.git@cd559899e783f6e754743713771d465d242807f2#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0
 -e git+https://github.com/adborden/swagger-py.git@4edd44884c56c8ac41e91c6505e8ace734bd6b75#egg=swaggerpy-master

--- a/zipcode_metro_raw/management/commands/downloadzipcodedata.py
+++ b/zipcode_metro_raw/management/commands/downloadzipcodedata.py
@@ -8,7 +8,6 @@ import zipfile
 
 from calaccess_raw import get_download_directory
 from calaccess_raw.management.commands import loadcalaccessrawfile
-from django.db import connection
 from optparse import make_option
 
 
@@ -38,6 +37,7 @@ class Command(loadcalaccessrawfile.Command):
     option_list = loadcalaccessrawfile.Command.option_list + custom_options
 
     def handle(self, *args, **options):
+        self.database = options['database']
         self.verbosity = int(options['verbosity'])
         self.max_lines_per_load = int(options.get('max_lines_per_load', 1000))
         self.data_dir = os.path.join(get_download_directory(), 'csv')
@@ -47,7 +47,6 @@ class Command(loadcalaccessrawfile.Command):
             self.download()
 
         if not options['skip_load']:
-            self.cursor = connection.cursor()
             self.load()
 
     def download(self):

--- a/zipcode_metro_raw/tests.py
+++ b/zipcode_metro_raw/tests.py
@@ -1,0 +1,27 @@
+import os.path as op
+import tempfile
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from zipcode_metro_raw.models import ZipCodeMetro
+
+
+@override_settings(CALACCESS_DOWNLOAD_DIR=tempfile.mkdtemp())
+class ZipcodeMetroTest(TestCase):
+
+    def test_download_agencies(self):
+        """
+        Tests a single file download
+        """
+
+        # Smoke test--make sure there are no errors.
+        call_command('downloadzipcodedata')
+
+        zipcodes_path = op.join(settings.CALACCESS_DOWNLOAD_DIR,
+                                'csv', 'zipcode_metro.csv')
+        self.assertTrue(op.exists(zipcodes_path), zipcodes_path)
+
+        # Check data
+        self.assertTrue(ZipCodeMetro.objects.all().count() > 0)


### PR DESCRIPTION
Integrate with a newer build of `calaccess_raw`, _without_ splitting data across databases in our project.

Also add a test for `ZipCodeMetro`.
