### PR TITLE
RF: Make BallotItemSelection, move properties to ReferendumSelection

### DIFF
--- a/ballot/admin.py
+++ b/ballot/admin.py
@@ -4,4 +4,4 @@ from . import models
 
 admin.site.register(models.Ballot)
 admin.site.register(models.BallotItem)
-admin.site.register(models.BallotItemResponse)
+admin.site.register(models.BallotItemSelection)

--- a/ballot/models.py
+++ b/ballot/models.py
@@ -48,7 +48,7 @@ class BallotItem(models.Model):
         return self.name
 
 
-class BallotItemResponse(models.Model):
+class BallotItemSelection(models.Model):
     """
     YES/NO to a referendum, or a candidate.
 

--- a/ballot/models.py
+++ b/ballot/models.py
@@ -48,18 +48,13 @@ class BallotItem(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class BallotItemResponse(models.Model):
     """
     YES/NO to a referendum, or a candidate.
-    """
-    # None indicates auto-set and needs manual intervention.
-    title = models.CharField(max_length=255)
-    brief = models.TextField(null=True, blank=True, default=None)
-    full_text = models.TextField(null=True, blank=True, default=None)
-    pro_statement = models.TextField(null=True, blank=True, default=None)
-    con_statement = models.TextField(null=True, blank=True, default=None)
-    ballot_item = models.ForeignKey('BallotItem')
 
-    def __str__(self):
-        return "%s on %s" % (self.title, self.ballot_item.name)
+    This is a *conceptually* abstract class, but exists
+    as a Django model so that finance can point to propositions
+    and candidates equally.
+    """
+    pro_statement = models.TextField(null=True, blank=True, default=None)
+    ballot_item = models.ForeignKey('BallotItem')

--- a/ballot/models.py
+++ b/ballot/models.py
@@ -56,5 +56,4 @@ class BallotItemSelection(models.Model):
     as a Django model so that finance can point to propositions
     and candidates equally.
     """
-    pro_statement = models.TextField(null=True, blank=True, default=None)
     ballot_item = models.ForeignKey('BallotItem')

--- a/finance/models.py
+++ b/finance/models.py
@@ -110,8 +110,8 @@ class Beneficiary(Committee):
     support = models.NullBooleanField(null=True, default=None,
                                       help_text="Whether funds are to support "
                                                 "(Y) or oppose (N)")
-    ballot_item_response = models.ForeignKey(
-        'ballot.BallotItemResponse', null=True, default=None)
+    ballot_item_selection = models.ForeignKey(
+        'ballot.BallotItemSelection', null=True, default=None)
 
     class Meta:
         verbose_name_plural = 'beneficiaries'
@@ -147,10 +147,10 @@ class IndependentMoney(models.Model):
     def __str__(self):
         val = "%s gave %s to %s @ %s" % (self.benefactor, self.amount,
                                          self.beneficiary, self.benefactor_zip)
-        if self.beneficiary.ballot_item_response is not None:
+        if self.beneficiary.ballot_item_selection is not None:
             val += " in %s %s" % (
                 'support of' if self.beneficiary.support else 'opposition to',
-                self.beneficiary.ballot_item_response)
+                self.beneficiary.ballot_item_selection)
         val += ", reported via %s on %s" % (
             self.reporting_period.form, self.report_date)
         return val

--- a/office_election/models.py
+++ b/office_election/models.py
@@ -104,7 +104,6 @@ class Candidate(BallotItemSelection, PersonMixin):
     """
     office_election = models.ForeignKey('OfficeElection')
     party = models.ForeignKey('Party', null=True, default=None)
-    con_statement = models.TextField(null=True, blank=True, default=None)
 
     def __init__(self, *args, **kwargs):
         super(Candidate, self).__init__(*args, **kwargs)

--- a/office_election/models.py
+++ b/office_election/models.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from ballot.models import BallotItem, BallotItemResponse
+from ballot.models import BallotItem, BallotItemSelection
 
 
 class SocialMediaMixin(models.Model):
@@ -98,7 +98,7 @@ class OfficeElection(BallotItem):
 
 
 @python_2_unicode_compatible
-class Candidate(BallotItemResponse, PersonMixin):
+class Candidate(BallotItemSelection, PersonMixin):
     """
     A person running for office.
     """

--- a/office_election/models.py
+++ b/office_election/models.py
@@ -104,11 +104,17 @@ class Candidate(BallotItemResponse, PersonMixin):
     """
     office_election = models.ForeignKey('OfficeElection')
     party = models.ForeignKey('Party', null=True, default=None)
+    con_statement = models.TextField(null=True, blank=True, default=None)
 
     def __init__(self, *args, **kwargs):
         super(Candidate, self).__init__(*args, **kwargs)
-        self.title = str(PersonMixin.__unicode__(self))
-        self.ballot_item = self.office_election
+        if getattr(self, 'ballot_item', None) is None:
+            self.ballot_item = self.office_election
+        elif getattr(self, 'office_election', None) is None:
+            self.office_election = self.ballot_item
+        else:
+            assert self.ballot_item.id == self.office_election.id
 
     def __str__(self):
-        return "%s for %s" % (self.title, str(self.office_election))
+        return "%s for %s" % (
+            PersonMixin.__str__(self), self.office_election)

--- a/office_election/tests.py
+++ b/office_election/tests.py
@@ -1,2 +1,39 @@
-# from django.test import TestCase
-# Create your tests here.
+from django.test import TestCase
+
+from office_election.models import Candidate, OfficeElection, Office
+from ballot.models import Ballot
+from locality.models import City, State
+
+
+class OfficeElectionTest(TestCase):
+    def test_create_candidate(self):
+        """
+        Candidates have extra logic in their initializer. Play with it.
+        """
+        state, _ = State.objects.get_or_create(name='California')
+        city, _ = City.objects.get_or_create(name='San Diego', state=state)
+        office, _ = Office.objects.get_or_create(name='Mayor', locality=city)
+        ballot, _ = Ballot.objects.get_or_create(locality=city)
+        kwargs = dict(first_name='Ben', last_name='Cip')
+
+        # Set via office_election
+        office_election, _ = OfficeElection.objects.get_or_create(
+            office=office, ballot=ballot)
+        cand = Candidate(office_election=office_election, **kwargs)
+        self.assertEqual(cand.office_election.id, cand.ballot_item.id,
+                         'office_election and ballot_item should match.')
+        cand.save()  # smoke test
+        Candidate.objects.all().delete()
+
+        # Set via ballot_item
+        office_election, _ = OfficeElection.objects.get_or_create(
+            office=office, ballot=ballot)
+        cand = Candidate(ballot_item=office_election, **kwargs)
+        self.assertEqual(cand.office_election.id, cand.ballot_item.id,
+                         'office_election and ballot_item should match.')
+
+        # Load
+        cand.save()
+        cand = Candidate.objects.all()[0]
+        self.assertEqual(cand.office_election.id, cand.ballot_item.id,
+                         'office_election and ballot_item should match.')

--- a/referendum/models.py
+++ b/referendum/models.py
@@ -4,9 +4,10 @@ Models related to a specific referendum on a ballot.
 
 from __future__ import unicode_literals
 
+from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from ballot.models import BallotItem
+from ballot.models import BallotItem, BallotItemResponse
 from office_election.models import SocialMediaMixin
 
 
@@ -24,3 +25,16 @@ class Referendum(BallotItem, SocialMediaMixin):
 
     def __str__(self):
         return "Prop %s: %s" % (self.number, self.name)
+
+
+@python_2_unicode_compatible
+class ReferendumResponse(BallotItemResponse, SocialMediaMixin):
+    """
+    A referendum response on the ballot (usually YES or NO)
+    """
+    # None indicates auto-set and needs manual intervention.
+    in_favor = models.NullBooleanField(null=True, blank=True, default=None)
+
+    def __str__(self):
+        return "'%s' on %s" % (
+            "FOR" if self.in_favor else "OPPOSED", self.ballot_item.name)

--- a/referendum/models.py
+++ b/referendum/models.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from ballot.models import BallotItem, BallotItemResponse
+from ballot.models import BallotItem, BallotItemSelection
 from office_election.models import SocialMediaMixin
 
 
@@ -17,7 +17,7 @@ class Referendum(BallotItem, SocialMediaMixin):
     A referendum on the ballot.
     """
     # TODO: Set up a save() event, or overload save(), to auto-populate
-    #   BallotItemResponses (YES/NO)
+    #   BallotItemSelections (YES/NO)
 
     def __init__(self, *args, **kwargs):
         super(Referendum, self).__init__(*args, **kwargs)
@@ -28,7 +28,7 @@ class Referendum(BallotItem, SocialMediaMixin):
 
 
 @python_2_unicode_compatible
-class ReferendumResponse(BallotItemResponse, SocialMediaMixin):
+class ReferendumSelection(BallotItemSelection, SocialMediaMixin):
     """
     A referendum response on the ballot (usually YES or NO)
     """


### PR DESCRIPTION
In #133 , @mikeubell points out how `BallotItemResponse` is a confusing model. I agree; it's really just an abstract entity for convenience, rather than a meaningful item. The `office_election` app extends it to represent `Candidate`. However, the `referendum` app does not extend `BallotItemResponse`, making it unclear what that object is really for.

The change here is to alias `BallotItemResponse` as `ReferendumResponse` in the `referendum` app. Hopefully this makes it clearer that `ReferendumResponse` and `Candidate` are the important models, representing the choice a voter would make on a ballot.

@mikeubell any thoughts here?
