### PR TITLE
Fix #90: Django issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8
+Django==1.8.1
 -e git://github.com/bcipolli/django-calaccess-raw-data.git@cd559899e783f6e754743713771d465d242807f2#egg=django-calaccess-raw-data
 mysqlclient
 Pillow==3.0.0


### PR DESCRIPTION
I opened this a while ago, but looks like this is affecting others (@rkiddy) so... let's fix it!

Updated `requirements.txt` to use Django 1.8.0 Parts of `calaccess_raw` don't work in Django 1.8.0, due to a Django bug.

Will merge this right away to unblock @rkiddy 
