### PR TITLE
STY: #28 remove unused max_lines_per_load options.

### DIFF
--- a/netfile_raw/management/commands/downloadnetfilerawdata.py
+++ b/netfile_raw/management/commands/downloadnetfilerawdata.py
@@ -33,14 +33,6 @@ custom_options = (
         help="Years to query (comma-separated)"
     ),
     make_option(
-        "--max-lines",
-        action="store",
-        dest="max_lines_per_load",
-        default=1000,
-        type=int,
-        help="Max # lines to load, per query"
-    ),
-    make_option(
         "--force",
         action="store_true",
         dest="force",
@@ -146,7 +138,7 @@ class Command(loadcalaccessrawfile.Command):
         self.csv = None
         self.database = options['database']
         self.verbosity = int(options['verbosity'])
-        self.max_lines_per_load = int(options['max_lines_per_load'])
+
         if options['agencies'] is None:
             self.agencies = []
         else:

--- a/zipcode_metro_raw/management/commands/downloadzipcodedata.py
+++ b/zipcode_metro_raw/management/commands/downloadzipcodedata.py
@@ -40,7 +40,6 @@ class Command(loadcalaccessrawfile.Command):
         self.csv = None
         self.database = options['database']
         self.verbosity = int(options['verbosity'])
-        self.max_lines_per_load = int(options.get('max_lines_per_load', 1000))
         self.data_dir = os.path.join(get_download_directory(), 'csv')
         self.zip_path = os.path.join(self.data_dir, 'zipcode_metro.zip')
 


### PR DESCRIPTION
There's no indication in our code, in the `calaccess_raw` code, [nor on Google](https://www.google.com/search?q=django+max_lines_per_load) that any `max_lines_per_load` option exists.

So, the right fix turns out to be: remove it :)
