### PR TITLE
Fix civic.json

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -3,13 +3,18 @@
   "thumbnailUrl": "https://raw.githubusercontent.com/caciviclab/caciviclab.github.io/fc6cd32ef50a8db7da7edc3df1bea2a424263f63/images/logo.png",
   "geography": "California",
   "type": "Web App",
+  "tags": [
+    "California",
+    "campaign finance",
+    "open data"
+  ],
   "needs": [
-    "django",
-    "angular",
-    "campaign finance experts"
+    {"need": "django"},
+    {"need": "angular"},
+    {"need": "campaign finance experts"}
   ],
   "categories": [
-    "finance",
-    "open data"
+    {"category": "finance"},
+    {"category": "open data"}
   ]
 }

--- a/disclosure/tests/test_civic_json.py
+++ b/disclosure/tests/test_civic_json.py
@@ -1,0 +1,53 @@
+import json
+import os.path as op
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class CivicJsonTest(TestCase):
+
+    def is_valid_civic_json(self, civic_json):
+
+        # Test top-level keys
+        good_keys = ('bornAt', 'categories', 'geography', 'needs',
+                     'politicalEntity', 'status', 'tags', 'thumbnailUrl',
+                     'type')
+        self.assertTrue(len(set(civic_json.keys()) - set(good_keys)) == 0,
+                        "Only recognized top-level keys")
+
+        # Test top-level values are strings.
+        for key in ('bornAt', 'geography', 'politicalEntity', 'status',
+                    'thumbnailUrl', 'type'):
+            self.assertTrue(isinstance(civic_json.get(key, ''), basestring),
+                            "%s value is a string" % key)
+
+        # Test top-level lists
+        for key in ('tags',):
+            self.assertTrue(isinstance(civic_json.get(key, []), list),
+                            "%s is a list" % key)
+            for ii, val in enumerate(civic_json.get(key, [])):
+                self.assertTrue(isinstance(val, basestring),
+                                "%s[%d] is a string" % (key, ii))
+
+        # Test second-level objects
+        for key_sing, key_plur in (('need', 'needs'),
+                                   ('category', 'categories')):
+            for ii, val in enumerate(civic_json.get(key_plur, {})):
+                self.assertTrue(
+                    key_sing in val and len(val) == 1,
+                    "%s[%d] is a %s dict" % (key_plur, ii, key_sing))
+                self.assertTrue(
+                    isinstance(val[key_sing], basestring),
+                    "%s[%d]['%s'] is a string" % (key_plur, ii, key_sing))
+
+        return True
+
+    def test_civic_json(self):
+        """ Test civic.json"""
+        json_path = op.join(settings.REPO_DIR, 'civic.json')
+        self.assertTrue(op.exists(json_path), json_path)
+
+        with open(json_path, 'r') as fp:
+            civic_json = json.load(fp)
+        self.assertTrue(self.is_valid_civic_json(civic_json))

--- a/disclosure/tests/test_docgen.py
+++ b/disclosure/tests/test_docgen.py
@@ -1,10 +1,10 @@
 import os
 from django.conf import settings
 from django.core.management import call_command
-from rest_framework.test import APITestCase
+from django.test import TestCase
 
 
-class DocGenerationTest(APITestCase):
+class DocGenerationTest(TestCase):
 
     def test_generate_docs(self):
         """ Test createcalaccessrawmodeldocs"""


### PR DESCRIPTION
Fixes #148 
- Add `tags` as per [CFAPI spec](https://github.com/codeforamerica/cfapi#civicjson)
- `needs` is an array of `need` objects as per [BetaNYC](https://github.com/BetaNYC/civic.json/blob/master/specification.md)
- `categories` is an array of `category` objects as per [BetaNYC](https://github.com/BetaNYC/civic.json/blob/master/specification.md)
