### PR TITLE
WIP: Fix swagger_nickname issue

### DIFF
--- a/ballot/urls/ballot.py
+++ b/ballot/urls/ballot.py
@@ -1,11 +1,12 @@
-from django.conf.urls import patterns, url
+from rest_framework.routers import SimpleRouter
+# from django.conf.urls import patterns, url
 from django.contrib import admin
 
 from ..views import ballot as views
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    url(r'^locality/(?P<locality_id>[0-9]+)/ballot/$', views.ballot_view,
-        name='locality_ballot'))
+api = SimpleRouter()
+api.register(r'locality/(?P<locality_id>[0-9]+)', views.BallotViewSet,
+             base_name='ballot')
+urlpatterns = api.urls

--- a/ballot/views/ballot.py
+++ b/ballot/views/ballot.py
@@ -1,81 +1,85 @@
-from rest_framework.decorators import api_view
+from rest_framework import viewsets
+from rest_framework.decorators import detail_route, list_route
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
+from ..serializers import BallotSerializer, ReferendumSerializer  # noqa
+# from ..models import Ballot
 
-@api_view(['GET'])
-def measure_view(request, measure_id):
+
+class BallotViewSet(viewsets.ViewSet):
     """
-    Display summarized disclosure information about a committee
+    TODO: docstring
     ---
-    parameters:
-      - name: measure_id
-        description: The measure_id
-        paramType: path
-        type: integer
-        required: true
+    ballot:
+      response_serializer: BallotSerializer
     """
-    return Response({
-        'measure_id': 1,
-        'city': {
-            'fips_id': 6075,
-            'location': {
-                'name': 'San Francisco'
-            }
-        },  # Not sure if city really makes sense here
-        'number': 'BB',
-        'full_text': 'Shall the Charter of the City of Oakland be amended to '
-                     ' provide the Public Ethics Commission greater '
-                     'independence, broader enforcement authority, powers',
-        'title': 'Ethics Commission Authority Increase Charter Amendment',
-        'supporting_count': 4,
-        'opposing_count': 6
-    }, content_type='application/json')
+    renderer_classes = [JSONRenderer]
 
+    @list_route(['GET'])
+    def ballot(self, request, locality_id):
+        return Response({
+            'ballot_id': 'ballot1',
+            'locality_id': str(locality_id),
+            'contests': [
+                {
+                    'contest_type': 'office',
+                    'name': 'Mayor'
+                },
+                {
+                    'contest_type': 'office',
+                    'name': 'City Auditor'
+                },
+                {
+                    'contest_type': 'office',
+                    'name': 'City Treasurer'
+                },
+                {
+                    'contest_type': 'office',
+                    'name': 'Distrit 1 City Council'
+                },
+                {
+                    'contest_type': 'office',
+                    'name': 'Distrit 3 City Council'
+                },
+                {
+                    'contest_type': 'office',
+                    'name': 'Distrit 5 City Council'
+                },
+                {
+                    'contest_type': 'referendum',
+                    'name': 'Measure AA'
+                },
+                {
+                    'contest_type': 'referendum',
+                    'name': 'Measure BB'
+                },
+                {
+                    'contest_type': 'referendum',
+                    'name': 'Measure CC'
+                }
+            ]
+        })
 
-@api_view(['GET'])
-def ballot_view(request, locality_id):
-    """
-    Display summarized ballot information
-    """
-    return Response({
-        'ballot_id': 'ballot1',
-        'locality_id': 'locality2',
-        'contests': [
-            {
-                'contest_type': 'office',
-                'name': 'Mayor'
-            },
-            {
-                'contest_type': 'office',
-                'name': 'City Auditor'
-            },
-            {
-                'contest_type': 'office',
-                'name': 'City Treasurer'
-            },
-            {
-                'contest_type': 'office',
-                'name': 'Distrit 1 City Council'
-            },
-            {
-                'contest_type': 'office',
-                'name': 'Distrit 3 City Council'
-            },
-            {
-                'contest_type': 'office',
-                'name': 'Distrit 5 City Council'
-            },
-            {
-                'contest_type': 'referendum',
-                'name': 'Measure AA'
-            },
-            {
-                'contest_type': 'referendum',
-                'name': 'Measure BB'
-            },
-            {
-                'contest_type': 'referendum',
-                'name': 'Measure CC'
-            }
-        ]
-    }, content_type='application/json')
+    @detail_route(['GET'])
+    def referendum(self, request, locality_id, pk=None):
+        """
+        Your docs
+        ---
+        """
+        return Response({
+            'measure_id': pk,
+            'city': {
+                'locality_id': locality_id,
+                'location': {
+                    'name': 'San Francisco'
+                }
+            },  # Not sure if city really makes sense here
+            'number': 'BB',
+            'full_text': 'Shall the Charter of the City of Oakland be amended '
+                         'to provide the Public Ethics Commission greater '
+                         'independence, broader enforcement authority, powers',
+            'title': 'Ethics Commission Authority Increase Charter Amendment',
+            'supporting_count': 4,
+            'opposing_count': 6
+        })

--- a/ballot/views/ballot.py
+++ b/ballot/views/ballot.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import api_view, detail_route, list_route
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
@@ -62,13 +62,13 @@ class BallotViewSet(viewsets.ViewSet):
         })
 
     @detail_route(['GET'])
-    def referendum(self, request, locality_id, pk=None):
+    def referendum(self, request, locality_id, referendum_id=None):
         """
-        Your docs
+        TODO: docstring
         ---
         """
         return Response({
-            'measure_id': pk,
+            'measure_id': measure_id,
             'city': {
                 'locality_id': locality_id,
                 'location': {

--- a/disclosure/swagger_nickname.py
+++ b/disclosure/swagger_nickname.py
@@ -1,0 +1,16 @@
+"""
+Provides the swagger "nickname" field, a friendly name for
+the swagger client methods.
+"""
+from rest_framework.views import get_view_name
+
+
+def view_name(cls, suffix=None):
+    """ Lowercases the view name.
+    Front-end will see search.search_view_get() vs. search.Search_View_GET()"""
+    if not suffix:
+        # Lowercase the default nickname. Default from:
+        # http://www.django-rest-framework.org/api-guide/settings/#view_name_function
+        return get_view_name(cls, suffix).lower()
+
+    return suffix.lower()

--- a/disclosure/tests/test_api_docs.py
+++ b/disclosure/tests/test_api_docs.py
@@ -10,5 +10,18 @@ class ApiDocsTests(APITestCase):
         self.client.get('/docs/')  # smoke test
 
     def test_api_docs(self):
+        """ Smoke test to make sure we don't break /docs/api-docs/"""
         resp = self.client.get('/docs/api-docs/')
         self.assertIn('apis', resp.data)
+
+    def test_api_docs_individually(self):
+        """ Smoke test to make sure we don't break individual api-docs"""
+        resp = self.client.get('/docs/api-docs/')
+        for api in resp.data['apis']:
+            api_path = '/docs/api-docs' + api['path']
+            doc_resp = self.client.get(api_path)
+            self.assertIn('apis', doc_resp.data, api['path'])
+            for sub_api in doc_resp.data['apis']:
+                for operation in sub_api['operations']:
+                    self.assertTrue(operation['nickname'].islower(),
+                                    '%s nickname is lowercase.' % api_path)

--- a/disclosure/urls.py
+++ b/disclosure/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.contrib import admin
 
+from rest_framework.routers import SimpleRouter
+
 from . import views
 
 admin.autodiscover()
@@ -27,15 +29,9 @@ urlpatterns = patterns(
     url(r'^locations/(?P<locality_id>[0-9]+)$', views.location_view,
         name='locality_detail'),
     url(r'^committee/(?P<committee_id>[0-9]+)$', views.committee_view,
-        name='committee_detail'),
+        name='committee_detail'))
 
-    # Funding queries for a specific locality.
-    url(r'^locality/(?P<locality_id>[0-9]+)/contributors/$',
-        views.contributor_view,
-        name='locality_contributors'),
-    url(r'^locality/(?P<locality_id>[0-9]+)/supporting/$',
-        views.supporting_view,
-        name='locality_supporting'),
-    url(r'^locality/(?P<locality_id>[0-9]+)/opposing/$',
-        views.opposing_view,
-        name='locality_opposing'))
+api = SimpleRouter()
+api.register(r'locality/(?P<locality_id>[0-9]+)', views.LocalityViewSet,
+             base_name='locality')
+urlpatterns += api.urls

--- a/disclosure/urls.py
+++ b/disclosure/urls.py
@@ -27,9 +27,7 @@ urlpatterns = patterns(
 
     # Details for specific objects
     url(r'^locations/(?P<locality_id>[0-9]+)$', views.location_view,
-        name='locality_detail'),
-    url(r'^committee/(?P<committee_id>[0-9]+)$', views.committee_view,
-        name='committee_detail'))
+        name='locality_detail'))
 
 api = SimpleRouter()
 api.register(r'locality/(?P<locality_id>[0-9]+)', views.LocalityViewSet,

--- a/disclosure/views.py
+++ b/disclosure/views.py
@@ -129,35 +129,6 @@ def committee_view(request, committee_id):
 
 
 class LocalityViewSet(viewsets.ViewSet):
-    @list_route(['GET'])
-    def contributor(self, request, locality_id):
-        """
-        Display summarized contributor information
-        ---
-        parameters:
-          - name: locality_id
-            description: The locality_id (can be city, county, state)
-            paramType: path
-            type: integer
-            required: true
-        """
-        return Response([
-            {
-                'name': 'Samantha Brooks',
-                'amount': 700,
-                'date': '2015-04-12'
-            },
-            {
-                'name': 'Lisa Sheppards',
-                'amount': 700,
-                'date': '2015-01-13'
-            },
-            {
-                'name': 'Raoul Esponsito',
-                'amount': 700,
-                'date': '2015-04-04'
-            }
-        ])
 
     @list_route(['GET'])
     def supporting(self, request, locality_id):

--- a/disclosure/views.py
+++ b/disclosure/views.py
@@ -1,7 +1,8 @@
 from django.db.models import Q
 from django.http import HttpResponse, Http404
 
-from rest_framework.decorators import api_view
+from rest_framework import viewsets
+from rest_framework.decorators import api_view, list_route
 from rest_framework.response import Response
 
 from locality.models import City
@@ -83,6 +84,7 @@ def location_view(request, locality_id):
         [(key, val.aggregate(tot=Sum(F('amount')))['tot'] or 0)  # 0 for empty
          for key, val in results_by_locality.items()])
 
+    print 'a'
     return Response({
         "location": {
             "name": locality.name or locality.short_name,
@@ -93,7 +95,7 @@ def location_view(request, locality_id):
         "contribution_count": num_contributions,
         "contribution_by_type": benefits_by_type,
         "contribution_by_area": total_by_locality,
-    }, content_type='application/json')
+    })
 
 
 @api_view(['GET'])
@@ -123,79 +125,78 @@ def committee_view(request, committee_id):
             'inside_state': 0.38,
             'outside_state': 0.06
         }
-    }, content_type='application/json')
+    })
 
 
-@api_view(['GET'])
-def contributor_view(request, locality_id):
-    """
-    Display summarized contributor information
-    ---
-    parameters:
-      - name: locality_id
-        description: The locality_id (can be city, county, state)
-        paramType: path
-        type: integer
-        required: true
-    """
-    return Response([
-        {
-            'name': 'Samantha Brooks',
-            'amount': 700,
-            'date': '2015-04-12'
-        },
-        {
-            'name': 'Lisa Sheppards',
-            'amount': 700,
-            'date': '2015-01-13'
-        },
-        {
-            'name': 'Raoul Esponsito',
-            'amount': 700,
-            'date': '2015-04-04'
-        }
-    ], content_type='application/json')
+class LocalityViewSet(viewsets.ViewSet):
+    @list_route(['GET'])
+    def contributor(self, request, locality_id):
+        """
+        Display summarized contributor information
+        ---
+        parameters:
+          - name: locality_id
+            description: The locality_id (can be city, county, state)
+            paramType: path
+            type: integer
+            required: true
+        """
+        return Response([
+            {
+                'name': 'Samantha Brooks',
+                'amount': 700,
+                'date': '2015-04-12'
+            },
+            {
+                'name': 'Lisa Sheppards',
+                'amount': 700,
+                'date': '2015-01-13'
+            },
+            {
+                'name': 'Raoul Esponsito',
+                'amount': 700,
+                'date': '2015-04-04'
+            }
+        ])
 
+    @list_route(['GET'])
+    def supporting(self, request, locality_id):
+        """
+        Display summarized supporting committee information
+        ---
+        parameters:
+          - name: locality_id
+            description: The locality_id (can be city, county, state)
+            paramType: path
+            type: integer
+            required: true
+        """
+        return Response([
+            {'name': 'Citizens for a Better Oakland', 'contributions': 185859},
+            {'name': 'Oaklanders for Ethical Government', 'contributions': 152330},  # noqa
+            {'name': 'Americans for Liberty', 'contributions': 83199},
+            {'name': 'Golden State Citizens for Positive Reform',
+             'contributions': 23988}
+        ], content_type='application/json')
 
-@api_view(['GET'])
-def supporting_view(request, locality_id):
-    """
-    Display summarized supporting committee information
-    ---
-    parameters:
-      - name: locality_id
-        description: The locality_id (can be city, county, state)
-        paramType: path
-        type: integer
-        required: true
-    """
-    return Response([
-        {'name': 'Citizens for a Better Oakland', 'contributions': 185859},
-        {'name': 'Oaklanders for Ethical Government', 'contributions': 152330},
-        {'name': 'Americans for Liberty', 'contributions': 83199},
-        {'name': 'Golden State Citizens for Positive Reform',
-         'contributions': 23988}
-    ], content_type='application/json')
-
-
-@api_view(['GET'])
-def opposing_view(request, locality_id):
-    """
-    Display summarized opposing committee information
-    ---
-    parameters:
-      - name: locality_id
-        description: The locality_id (can be city, county, state)
-        paramType: path
-        type: integer
-        required: true
-    """
-    return Response([
-        {'name': 'The Public Commission for Ethical Civic Reform',
-         'contributions': 15040},
-        {'name': 'The Committee of True Americans who Dearly Love America '
-                 'and Liberty', 'contributions': 7943}
-    ], content_type='application/json')
+    @list_route(['GET'])
+    def opposing(self, request, locality_id):
+        """
+        Display summarized opposing committee information
+        ---
+        parameters:
+          - name: locality_id
+            description: The locality_id (can be city, county, state)
+            paramType: path
+            type: integer
+            required: true
+        """
+        return Response([
+            {'name': 'The Public Commission for Ethical Civic Reform',
+             'contributions': 15040},
+            {'name': 'The Committee of True Americans who Dearly Love America '
+                     'and Liberty', 'contributions': 7943}
+        ])
 
 
 def homepage_view(request):

--- a/finance/urls.py
+++ b/finance/urls.py
@@ -1,7 +1,13 @@
+from django.contrib import admin
+
 from rest_framework.routers import SimpleRouter
 
 from . import views
 
+
+admin.autodiscover()
+
 api = SimpleRouter()
-api.register(r'contributions', views.IndependentMoneyViewSet)
+api.register(r'money', views.IndependentMoneyViewSet)
+api.register(r'committee', views.CommitteeViewSet)
 urlpatterns = api.urls

--- a/finance/views.py
+++ b/finance/views.py
@@ -1,8 +1,9 @@
 from rest_framework import viewsets
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework.decorators import detail_route
 
-from .models import IndependentMoney
+from .models import IndependentMoney, Committee
 from .serializers import IndependentMoneySerializer
 
 
@@ -10,10 +11,9 @@ class IndependentMoneyViewSet(viewsets.ViewSet):
     """
     A contribution is money that a filing committee has received.
     ---
-    retrieve:
-      response_serializer: IndependentMoneySerializer
     list:
-      response_serializer: IndependentMoneySerializer
+      response_serializer: IndependentMoneySerializer:
+
     """
     renderer_classes = [JSONRenderer]
     queryset = IndependentMoney.objects.all()
@@ -23,7 +23,60 @@ class IndependentMoneyViewSet(viewsets.ViewSet):
         obj = IndependentMoney.objects.all()[1:10]
         return Response(IndependentMoneySerializer(obj, many=True).data)
 
-    def retrieve(self, request, pk=None, format=None):
+
+class CommitteeViewSet(viewsets.ViewSet):
+    """
+    A contribution is money that a filing committee has received.
+    ---
+    """
+    renderer_classes = [JSONRenderer]
+    queryset = Committee.objects.all()
+
+    def retrieve(self, request, pk, format=None):
         """ Get a single contribution """
-        obj = IndependentMoney.objects.get(id=pk)
-        return Response(IndependentMoneySerializer(obj).data)
+        return Response({
+            'committee_id': 1234,
+            'name': 'Americans for Liberty',
+            'contribution_by_type': {
+                'unitemized': 2916394,
+                'self_funded': 512554,
+                'political_party': 6426112,
+                'individual': 11134547,
+                'recipient_committee': 986229
+            },
+            'contribution_by_area': {
+                'inside_location': 0.56,
+                'inside_state': 0.38,
+                'outside_state': 0.06
+            }
+        })
+
+    @detail_route(['GET'])
+    def contributors(self, request, pk):
+        """
+        Display summarized contributor information
+        ---
+        parameters:
+          - name: locality_id
+            description: The locality_id (can be city, county, state)
+            paramType: path
+            type: integer
+            required: true
+        """
+        return Response([
+            {
+                'name': 'Samantha Brooks',
+                'amount': 700,
+                'date': '2015-04-12'
+            },
+            {
+                'name': 'Lisa Sheppards',
+                'amount': 700,
+                'date': '2015-01-13'
+            },
+            {
+                'name': 'Raoul Esponsito',
+                'amount': 700,
+                'date': '2015-04-04'
+            }
+        ])


### PR DESCRIPTION
https://github.com/caciviclab/disclosure-backend/commit/5ee514a8eb9eb28bc59628c3c80956dbd38af7d0 removed the `swagger_nickname` file, which exposes friendlier names to swagger clients. This led to the error detailed in #149 

In reinstating the old code, I found:
- Our current URL structure leads to strange nicknames for `locality`: `get`, `get_0_1`, `get_0_2`
- If `None` is returned by our function, this causes swagger to raise an error.

The current code:
- Adds tests for `nickname`, to make sure this system is at least minimally verified
- lowercases the default nickname (based on the view name), so that client methods are more meaningful (e.g. `ballot_view_get`).
- never returns `None`

@adborden I'm not sure this is the right fix. Can you review the above and comment? Thanks!
