### PR TITLE
Admin ordering

### DIFF
--- a/ballot/models/ballot.py
+++ b/ballot/models/ballot.py
@@ -33,6 +33,9 @@ class Ballot(models.Model):
         return '%s election for %s' % (
             str(self.date), str(self.locality))
 
+    class Meta:
+        ordering = ('date', 'locality__name', 'locality__short_name')
+
 
 @python_2_unicode_compatible
 class BallotItem(models.Model):
@@ -58,6 +61,10 @@ class BallotItem(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ('ballot__date', 'ballot__locality__short_name',
+                    'ballot__locality__name', 'number')
+
 
 @python_2_unicode_compatible
 class BallotItemSelection(models.Model, ReverseLookupStringMixin):
@@ -73,3 +80,8 @@ class BallotItemSelection(models.Model, ReverseLookupStringMixin):
     def __str__(self):
         return (ReverseLookupStringMixin.__str__(self) or
                 str(self.ballot_item))
+
+    class Meta:
+        ordering = ('ballot_item__ballot__date',
+                    'ballot_item__ballot__locality__short_name',
+                    'ballot_item__ballot__locality__name')

--- a/ballot/models/office_election.py
+++ b/ballot/models/office_election.py
@@ -37,6 +37,7 @@ class Party(SocialMediaMixin):
 
     class Meta:
         verbose_name_plural = 'parties'
+        ordering = ('name',)
 
 
 @python_2_unicode_compatible
@@ -61,6 +62,7 @@ class PersonMixin(SocialMediaMixin):
 
     class Meta:
         abstract = True
+        ordering = ('last_name', 'first_name', 'middle_name')
 
 
 @python_2_unicode_compatible
@@ -77,6 +79,10 @@ class Office(models.Model):
     def __str__(self):
         return "Office for %s in %s" % (
             self.name, str(self.locality))
+
+    class Meta:
+        ordering = ('locality__short_name', 'locality__name',
+                    'name')
 
 
 @python_2_unicode_compatible
@@ -96,6 +102,9 @@ class OfficeElection(BallotItem):
         return "Election of %s in %s (on %s)" % (
             self.office.name, str(self.office.locality),
             self.ballot.date)
+
+    class Meta:
+        ordering = BallotItem._meta.ordering + ('office__name',)
 
 
 @python_2_unicode_compatible
@@ -119,3 +128,8 @@ class Candidate(BallotItemSelection, PersonMixin):
         # See https://code.djangoproject.com/ticket/25218 on why __unicode__
         return "%s for %s" % (  # use unicode to avoid recursion error
             PersonMixin.__unicode__(self), self.office_election)
+
+    class Meta:
+        ordering = (BallotItemSelection._meta.ordering +
+                    ('office_election__office__name',) +
+                    PersonMixin._meta.ordering)

--- a/disclosure/tests/test_api_search.py
+++ b/disclosure/tests/test_api_search.py
@@ -1,5 +1,4 @@
 from django.core.urlresolvers import reverse
-from django.db.models import Q
 from rest_framework.test import APITestCase
 
 from finance.tests.test_command import WithForm460ADataTest
@@ -13,15 +12,25 @@ class SearchTests(WithForm460ADataTest, APITestCase):
         WithForm460ADataTest.setUpClass()
         APITestCase.setUpClass()
 
-    def test_search_city(self):
+    def test_search_city_with_data(self):
         # Get first city with non-None name
-        city = City.objects.filter(~Q(name=None))[0]
+        city = City.objects.get(name='Murrieta')
 
         search_url = '%s?q=%s' % (reverse('search'), city.name)
         resp = self.client.get(search_url)
+        self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.data), 1)
 
         row = resp.data[0]
         self.assertIn('id', row)
         self.assertEqual(row['name'], city.name)
         self.assertEqual(row['id'], city.id)
+
+    def test_search_city_no_data(self):
+        # Get first city with non-None name
+        city = City.objects.get(name='Anaheim')
+
+        search_url = '%s?q=%s' % (reverse('search'), city.name)
+        resp = self.client.get(search_url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 0)

--- a/finance/models.py
+++ b/finance/models.py
@@ -32,6 +32,9 @@ class Committee(SocialMediaMixin, AddressMixin):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ('name', 'locality__name', 'locality__short_name')
+
 
 @python_2_unicode_compatible
 class CorporationMixin(SocialMediaMixin, AddressMixin):
@@ -46,6 +49,7 @@ class CorporationMixin(SocialMediaMixin, AddressMixin):
 
     class Meta:
         abstract = True
+        ordering = ('name', 'locality__name', 'locality__short_name')
 
 
 @python_2_unicode_compatible
@@ -71,6 +75,9 @@ class Form(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ('locality__name', 'locality__short_name', 'name')
+
 
 @python_2_unicode_compatible
 class Benefactor(models.Model, ReverseLookupStringMixin):
@@ -93,6 +100,10 @@ class Benefactor(models.Model, ReverseLookupStringMixin):
         return (ReverseLookupStringMixin.__str__(self) or
                 self.benefactor_type)
 
+    class Meta:
+        ordering = ('benefactor_locality__name',
+                    'benefactor_locality__short_name')
+
 
 @python_2_unicode_compatible
 class PersonBenefactor(Benefactor, PersonMixin):
@@ -109,6 +120,9 @@ class PersonBenefactor(Benefactor, PersonMixin):
         # See https://code.djangoproject.com/ticket/25218 on why __unicode__
         return PersonMixin.__unicode__(self)
 
+    class Meta:
+        ordering = Benefactor._meta.ordering + PersonMixin._meta.ordering
+
 
 @python_2_unicode_compatible
 class CorporationBenefactor(Benefactor, CorporationMixin):
@@ -123,6 +137,9 @@ class CorporationBenefactor(Benefactor, CorporationMixin):
     def __str__(self):
         # See https://code.djangoproject.com/ticket/25218 on why __unicode__
         return CorporationMixin.__unicode__(self)
+
+    class Meta:
+        ordering = Benefactor._meta.ordering + CorporationMixin._meta.ordering
 
 
 @python_2_unicode_compatible
@@ -140,6 +157,9 @@ class CommitteeBenefactor(Benefactor, Committee):
         # See https://code.djangoproject.com/ticket/25218 on why __unicode__
         return Committee.__unicode__(self)
 
+    class Meta:
+        ordering = Benefactor._meta.ordering + Committee._meta.ordering
+
 
 class Beneficiary(Committee):
     """
@@ -155,6 +175,7 @@ class Beneficiary(Committee):
 
     class Meta:
         verbose_name_plural = 'beneficiaries'
+        ordering = Committee._meta.ordering
 
 
 @python_2_unicode_compatible
@@ -166,6 +187,9 @@ class ReportingPeriod(models.Model):
 
     def __str__(self):
         return '%s to %s' % (self.period_start or '', self.period_end or '')
+
+    class Meta:
+        ordering = ('period_start', 'period_end')
 
 
 @python_2_unicode_compatible
@@ -202,3 +226,7 @@ class IndependentMoney(models.Model):
 
     class Meta:
         verbose_name_plural = 'independent money'
+        ordering = ('-reporting_period__period_start',
+                    '-reporting_period__period_end',
+                    '-beneficiary__ballot_item_selection__ballot_item__ballot__date',  # noqa
+                    '-report_date', )

--- a/locality/models.py
+++ b/locality/models.py
@@ -28,6 +28,7 @@ class Locality(models.Model, ReverseLookupStringMixin):
 
     class Meta:
         verbose_name_plural = 'localities'
+        ordering = ('name', 'short_name')
 
 
 class FipsMixin(Locality):
@@ -53,6 +54,7 @@ class City(FipsMixin):
 
     class Meta:
         verbose_name_plural = 'cities'
+        ordering = ('state__short_name', 'county', 'name', 'short_name')
 
 
 @python_2_unicode_compatible
@@ -68,6 +70,7 @@ class County(FipsMixin):
 
     class Meta:
         verbose_name_plural = 'counties'
+        ordering = ('state__short_name', 'name', 'short_name')
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Depends on #160; fixes #159 

This adds meaningful ordering to all models, for:
- Listing models in the admin panel
- Drop-downs in model edit pages.

This is nice :dancers: 
