### PR TITLE
ENH: generate ER diagrams for auto-documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 language: python
 
-sudo: false
+python:
+ - "2.7"
+
+sudo: required
 
 cache:
+  apt: true
+  pip: true
   directories:
     - $HOME/.cache/pip
     - $HOME/data
     - $HOME/disclosure-backend/data
 
-python:
- - "2.7"
-
 env:
     global:
          - XDG_CACHE_HOME=$HOME/.cache/
 
+before_install:
+  - sudo apt-get install graphviz
+
 install:
-  - pip install flake8 pyflakes coverage
   - pip install python-coveralls nose-cov
   - pip install -r requirements.txt
+  - pip install -r requirements_dev.txt
 
 script: # Run test
   - make test

--- a/disclosure/management/commands/generate_project_er_diagram.py
+++ b/disclosure/management/commands/generate_project_er_diagram.py
@@ -1,0 +1,69 @@
+import importlib
+import os
+
+from django.conf import settings
+from django.core.management import call_command
+from django.db import models
+
+from calaccess_raw.management.commands import CalAccessCommand
+
+
+def get_disclosure_app_list():
+    # Get list of models from apps after those ending in _raw,
+    # which should be independent of the main project
+    app_list = []
+    start_collecting = False
+    for app in settings.INSTALLED_APPS:
+        if app.endswith('_raw'):  # never collect *_raw
+            start_collecting = True
+        elif start_collecting:
+            app_list.append(app)
+    return app_list
+
+
+def get_mixin_models(app_list=None):
+    # Get list of abstract 'mixin' models to exclude;
+    # they make the diagram messy.
+    mixin_models = []
+    for app in (app_list or get_disclosure_app_list()):
+        try:
+            mod = importlib.import_module(app + '.models')
+        except:
+            continue
+        for obj_name in dir(mod):
+            obj = getattr(mod, obj_name)
+            try:
+                if (issubclass(obj, models.Model) and
+                        obj.__name__.endswith('Mixin')):
+                    mixin_models.append(obj.__name__)
+            except:
+                continue
+    return mixin_models
+
+
+class Command(CalAccessCommand):
+    help = 'Generate documentation for models'
+
+    def handle(self, *args, **kwargs):
+        self.docs_dir = os.path.join(settings.REPO_DIR, 'docs')
+
+        app_list = get_disclosure_app_list()
+        mixin_models = get_mixin_models(app_list)
+
+        # Create the output path
+        if not os.path.exists(self.docs_dir):
+            os.makedirs(self.docs_dir)
+
+        # Generate the database relationships
+        out_file = os.path.join(self.docs_dir, 'model-relationships.png')
+        call_command('graph_models', *app_list,
+                     group_models=True, inheritance=False,
+                     outputfile=out_file,
+                     exclude_models=','.join(mixin_models))
+
+        # Generate the inheritance diagram
+        out_file = os.path.join(self.docs_dir, 'model-inheritance.png')
+        call_command('graph_models', *app_list,
+                     group_models=True, inheritance=True,
+                     outputfile=out_file,
+                     exclude_models=','.join(mixin_models))

--- a/disclosure/settings.py
+++ b/disclosure/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_extensions',
     'rest_framework',
     'rest_framework_swagger',
     'corsheaders',

--- a/disclosure/tests/test_docgen.py
+++ b/disclosure/tests/test_docgen.py
@@ -1,14 +1,23 @@
+import glob
 import os
+
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
 
 class DocGenerationTest(TestCase):
+    docs_dir = os.path.join(settings.REPO_DIR, 'docs')
 
-    def test_generate_docs(self):
+    def test_generate_calaccess_model_docs(self):
         """ Test createcalaccessrawmodeldocs"""
         call_command('createcalaccessrawmodeldocs')
         # Didn't throw; check some minimum level of output.
-        docs_dir = os.path.join(settings.REPO_DIR, 'docs')
-        self.assertTrue(os.path.exists(docs_dir))
+        self.assertTrue(os.path.exists(self.docs_dir))
+
+    def test_create_er(self):
+        call_command('generate_project_er_diagram')
+        self.assertTrue(os.path.exists(self.docs_dir))
+
+        png_files = glob.glob(os.path.join(self.docs_dir, 'model-*.png'))
+        self.assertEqual(len(png_files), 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow==3.0.0
 django-rest-swagger
 django-cors-headers==1.1.0
 pandas
+django-extensions

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 ipython
 flake8
 coverage
+pygraphviz

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ ipython
 flake8
 coverage
 pygraphviz
+graphviz


### PR DESCRIPTION
@tdooner Showed some cool ER diagrams; let's have a command to generate clean ones (no mixins).

The code should work regardless of new apps that we add or if we add in new mixins.

Without and with model inheritance:
![model-relationships](https://cloud.githubusercontent.com/assets/4072455/12636770/84e05856-c544-11e5-882a-2fc68bc97c79.png)
![model-inheritance](https://cloud.githubusercontent.com/assets/4072455/12636771/84e0647c-c544-11e5-8f87-756e4950ddac.png)
