### PR TITLE
ENH: skip duplicate rows (and assert the values are as expected).

### DIFF
--- a/finance/tests/test_command.py
+++ b/finance/tests/test_command.py
@@ -47,3 +47,14 @@ class XformNetfileRawDataTest(TestCase):
         Tests a single file download, with verbosity=1
         """
         self.test_xformnetfilerawdata(verbosity=1)
+
+    def test_xformnetfilerawdata_twice(self):
+        """
+        Tests a single file download, with verbosity=1
+        """
+        self.test_xformnetfilerawdata()
+        num_rows = IndependentMoney.objects.all().count()
+
+        self.test_xformnetfilerawdata(verbosity=1)  # print "skip"
+        self.assertEqual(num_rows, IndependentMoney.objects.all().count(),
+                         'no new rows after running twice')


### PR DESCRIPTION
@mikeubell Rather than parse and re-save rows that already exist in the database, this code detects them and skips them.

This should allow us to import the same data multiple times and skip over already-imported rows many times, helping accomplish #81 and #125
