### PR TITLE
Hide/show models in admin, to be useful for data entrants.

### DIFF
--- a/ballot/admin/ballot.py
+++ b/ballot/admin/ballot.py
@@ -3,5 +3,3 @@ from django.contrib import admin
 from ..models import ballot as models
 
 admin.site.register(models.Ballot)
-admin.site.register(models.BallotItem)
-admin.site.register(models.BallotItemSelection)

--- a/ballot/admin/office_election.py
+++ b/ballot/admin/office_election.py
@@ -2,6 +2,5 @@ from django.contrib import admin
 
 from ..models import office_election as models
 
-admin.site.register(models.Party)
-admin.site.register(models.Office)
 admin.site.register(models.Candidate)
+admin.site.register(models.OfficeElection)

--- a/disclosure/admin.py
+++ b/disclosure/admin.py
@@ -2,5 +2,6 @@ from django.contrib import admin
 from django.db import router
 
 for model in admin.site._registry.keys():
+    # Eliminate *_raw from the admin panel.
     if router.db_for_write(model=model) != 'default':
         admin.site.unregister(model)

--- a/finance/admin.py
+++ b/finance/admin.py
@@ -11,10 +11,8 @@ class OtherBenefactorAdmin(admin.ModelAdmin):
     exclude = ['benefactor_locality']
 
 
-admin.site.register(models.Form)
-admin.site.register(models.PersonBenefactor)
-admin.site.register(models.OtherBenefactor, OtherBenefactorAdmin)
-admin.site.register(models.CommitteeBenefactor, CommitteeBenefactorAdmin)
 admin.site.register(models.Beneficiary)
-admin.site.register(models.ReportingPeriod)
+admin.site.register(models.PersonBenefactor)
+admin.site.register(models.OtherBenefactor)
+admin.site.register(models.CommitteeBenefactor)
 admin.site.register(models.IndependentMoney)

--- a/locality/admin.py
+++ b/locality/admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 
 from . import models
 
-admin.site.register(models.Locality)
 admin.site.register(models.City)
 admin.site.register(models.County)
 admin.site.register(models.State)


### PR DESCRIPTION
Some abstract models (e.g. `BallotItem`, `BallotItemSelection`) were being shown in admin, while some critical models (e.g. `Beneficiary`) were not.

New:
![image](https://cloud.githubusercontent.com/assets/4072455/12958340/30f65f2c-cfff-11e5-8fd2-a2a1a398c33e.png)

Old:
![image](https://cloud.githubusercontent.com/assets/4072455/12958352/3e1e5574-cfff-11e5-99df-92e6bcb48f42.png)
