### PR TITLE
fix #192, order admin fields, fix help_text

### DIFF
--- a/ballot/admin/ballot.py
+++ b/ballot/admin/ballot.py
@@ -2,4 +2,5 @@ from django.contrib import admin
 
 from ..models import ballot as models
 
+
 admin.site.register(models.Ballot)

--- a/ballot/admin/office_election.py
+++ b/ballot/admin/office_election.py
@@ -2,5 +2,17 @@ from django.contrib import admin
 
 from ..models import office_election as models
 
-admin.site.register(models.Candidate)
+
+class CandidateAdmin(admin.ModelAdmin):
+    # We don't want to display unnecessary or calculated fields.
+    # In particular locality choices take a while to populate.
+    fields = ('ballot_item', 'first_name', 'middle_name', 'last_name', 'party',
+              'photo_url', 'website_url', 'facebook_url', 'twitter_url')
+
+    assert len(models.Candidate._meta.get_fields()) - len(fields) == 4, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.Candidate._meta.get_fields()))
+
+
+admin.site.register(models.Candidate, CandidateAdmin)
 admin.site.register(models.OfficeElection)

--- a/ballot/admin/referendum.py
+++ b/ballot/admin/referendum.py
@@ -2,4 +2,16 @@ from django.contrib import admin
 
 from ..models import referendum as models
 
-admin.site.register(models.Referendum)
+
+class ReferendumAdmin(admin.ModelAdmin):
+    # We don't want to display unnecessary or calculated fields.
+    # In particular locality choices take a while to populate.
+    fields = ('title', 'number', 'ballot',
+              'website_url', 'facebook_url', 'twitter_url')
+
+    assert len(models.Referendum._meta.get_fields()) - len(fields) == 5, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.Referendum._meta.get_fields()))
+
+
+admin.site.register(models.Referendum, ReferendumAdmin)

--- a/ballot/models/referendum.py
+++ b/ballot/models/referendum.py
@@ -18,9 +18,8 @@ class Referendum(BallotItem, SocialMediaMixin):
     """
     # TODO: Set up a save() event, or overload save(), to auto-populate
     #   BallotItemSelections (YES/NO)
-    name = models.CharField(
-        max_length=255, help_text='The referendum number or the name '
-                                  'of the office.')
+    title = models.CharField(
+        max_length=255, help_text='The referendum title')
     number = models.CharField(
         max_length=5, null=True, default=None,
         help_text="The referendum's number or letter.")
@@ -30,10 +29,10 @@ class Referendum(BallotItem, SocialMediaMixin):
         self.contest_type = 'R'
 
     def __str__(self):
-        return "Prop %s: %s" % (self.number, self.name)
+        return "Prop %s: %s" % (self.number, self.title)
 
     class Meta:
-        ordering = BallotItem._meta.ordering + ('number', 'name')
+        ordering = BallotItem._meta.ordering + ('number', 'title')
 
 
 @python_2_unicode_compatible
@@ -46,4 +45,4 @@ class ReferendumSelection(BallotItemSelection, SocialMediaMixin):
 
     def __str__(self):
         return "'%s' on %s" % (
-            "FOR" if self.in_favor else "OPPOSED", self.ballot_item.referendum.name)
+            "FOR" if self.in_favor else "OPPOSED", self.ballot_item.referendum.title)

--- a/ballot/tests/test_api_referendum.py
+++ b/ballot/tests/test_api_referendum.py
@@ -16,5 +16,5 @@ class MeasureAPITests(WithForm460ADataTest, APITestCase):
         resp = self.client.get(reverse('referendum_get', kwargs={'referendum_id': 1}))
 
         self.assertIn('id', resp.data)
-        self.assertIn('name', resp.data)
+        self.assertIn('title', resp.data)
         self.assertIn('number', resp.data)

--- a/ballot/tests/test_referendum.py
+++ b/ballot/tests/test_referendum.py
@@ -19,7 +19,7 @@ class ReferendumTest(TestCase):
         city, _ = City.objects.get_or_create(name='San Diego', state=state)
         ballot, _ = Ballot.objects.get_or_create(locality=city)
         referendum, _ = Referendum.objects.get_or_create(
-            ballot=ballot, name='Ref1', number='BB')
+            ballot=ballot, title='Ref1', number='BB')
         selection, _ = ReferendumSelection.objects.get_or_create(
             ballot_item=referendum, in_favor=True)
 

--- a/ballot/views/referendum.py
+++ b/ballot/views/referendum.py
@@ -23,5 +23,5 @@ class ReferendumViewSet(viewsets.ViewSet):
         return Response({
             'id': int(referendum_id),
             'number': 'BB',
-            'name': 'Ethics Commission Authority Increase Charter Amendment',
+            'title': 'Ethics Commission Authority Increase Charter Amendment',
         })

--- a/finance/admin.py
+++ b/finance/admin.py
@@ -3,16 +3,64 @@ from django.contrib import admin
 from . import models
 
 
-class BenefactorAdmin(admin.ModelAdmin):
-    exclude = ('benefactor_type',)
+class CommitteeBenefactorAdmin(admin.ModelAdmin):
+    # We don't want to display unnecessary or calculated fields.
+    # In particular locality choices take a while to populate.
+    # Also put the fields in a logical order for filling the form.
+    fields = ('name', 'type', 'filer_id', 'street', 'city', 'zip_code',
+              'photo_url', 'website_url', 'facebook_url', 'twitter_url')
+
+    assert len(models.CommitteeBenefactor._meta.get_fields()) - \
+        len(fields) == 9, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.CommitteeBenefactor._meta.get_fields()))
 
 
-class CommitteeBenefactorAdmin(BenefactorAdmin):
-    exclude = BenefactorAdmin.exclude + ('benefactor_locality',)
+class OtherBenefactorAdmin(admin.ModelAdmin):
+    fields = ('name', 'benefactor_type', 'street', 'city', 'zip_code',
+              'photo_url', 'website_url', 'facebook_url', 'twitter_url')
 
-admin.site.register(models.Beneficiary)
-admin.site.register(models.PersonBenefactor, BenefactorAdmin)
-admin.site.register(models.PartyBenefactor, BenefactorAdmin)
-admin.site.register(models.OtherBenefactor, BenefactorAdmin)
+    assert len(models.OtherBenefactor._meta.get_fields()) - \
+        len(fields) == 6, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.OtherBenefactor._meta.get_fields()))
+
+
+class PersonBenefactorAdmin(admin.ModelAdmin):
+    fields = ('first_name', 'middle_name', 'last_name', 'occupation',
+              'benefactor_type', 'street', 'city', 'zip_code',
+              'photo_url', 'website_url', 'facebook_url', 'twitter_url')
+
+    assert len(models.PersonBenefactor._meta.get_fields()) - \
+        len(fields) == 5, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.PersonBenefactor._meta.get_fields()))
+
+
+class BeneficiaryAdmin(admin.ModelAdmin):
+    fields = ('name', 'type', 'filer_id', 'support', 'ballot_item_selection',
+              'street', 'city', 'zip_code',
+              'photo_url', 'website_url', 'facebook_url', 'twitter_url')
+
+    assert len(models.Beneficiary._meta.get_fields()) - \
+        len(fields) == 5, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.Beneficiary._meta.get_fields()))
+
+
+class IndependentMoneyAdmin(admin.ModelAdmin):
+    fields = ('benefactor', 'benefactor_zip', 'beneficiary',
+              'amount', 'cumulative_amount', 'report_date', 'reporting_period',
+              'source', 'source_xact_id')
+
+    assert len(models.IndependentMoney._meta.get_fields()) - \
+        len(fields) == 1, \
+        "Make sure there are no new fields. %r %r " % \
+        (len(fields), len(models.IndependentMoney._meta.get_fields()))
+
+
+admin.site.register(models.Beneficiary, BeneficiaryAdmin)
+admin.site.register(models.PersonBenefactor, PersonBenefactorAdmin)
+admin.site.register(models.OtherBenefactor, OtherBenefactorAdmin)
 admin.site.register(models.CommitteeBenefactor, CommitteeBenefactorAdmin)
-admin.site.register(models.IndependentMoney)
+admin.site.register(models.IndependentMoney, IndependentMoneyAdmin)

--- a/finance/management/commands/xformnetfilerawdata.py
+++ b/finance/management/commands/xformnetfilerawdata.py
@@ -229,7 +229,7 @@ def parse_candidate_info(row, ballot, verbosity=1):
 
 def parse_referendum_info(row, ballot, verbosity=1):
     referendum, _ = Referendum.objects.get_or_create(
-        name='Unknown', ballot=ballot)
+        title='Unknown', ballot=ballot)
     selection, _ = ReferendumSelection.objects.get_or_create(
         ballot_item=referendum,
         in_favor=True)


### PR DESCRIPTION
I decided to put the fields in the Admin interface in a more reasonable order, e.g. Name first.
I dropped the ballot_type and photo_url from the referendum page as the latter is set by the initializer and the latter does not make much sense.  Let me know if I missed any significant fields from this or other pages.
