### PR TITLE
Fix for #204 - admin fails for new OfficeElection, Candidate

### DIFF
--- a/ballot/models/office_election.py
+++ b/ballot/models/office_election.py
@@ -96,8 +96,6 @@ class OfficeElection(BallotItem):
     def __init__(self, *args, **kwargs):
         super(OfficeElection, self).__init__(*args, **kwargs)
         self.contest_type = 'O'
-        # set BallotItem fields from Office
-        self.name = str(self)
 
     def __str__(self):
         return "Election of %s in %s (on %s)" % (
@@ -118,12 +116,15 @@ class Candidate(BallotItemSelection, PersonMixin):
 
     def __init__(self, *args, **kwargs):
         super(Candidate, self).__init__(*args, **kwargs)
-        if getattr(self, 'ballot_item', None) is None:
-            self.ballot_item = self.office_election
-        elif getattr(self, 'office_election', None) is None:
-            self.office_election = self.ballot_item
-        else:
+        has_ballot_item = getattr(self, 'ballot_item', None) is not None
+        has_office_election = getattr(self, 'office_election', None) is not None
+
+        if has_ballot_item and has_office_election:
             assert self.ballot_item.id == self.office_election.id
+        elif has_ballot_item:
+            self.office_election = self.ballot_item
+        elif has_office_election:
+            self.ballot_item = self.office_election
 
     def __str__(self):
         # See https://code.djangoproject.com/ticket/25218 on why __unicode__

--- a/ballot/tests/test_ballot.py
+++ b/ballot/tests/test_ballot.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+from ballot.models import Ballot
+
+
+class ObjectCreateTest(TestCase):
+    def test_create_empty(self):
+        ballot = Ballot()  # noqa

--- a/ballot/tests/test_office_election.py
+++ b/ballot/tests/test_office_election.py
@@ -1,11 +1,19 @@
 from django.test import TestCase
 
-from ballot.models import Ballot
-from ballot.models import Candidate, OfficeElection, Office
+from ballot.models import Ballot, Candidate, Office, OfficeElection
 from locality.models import City, State
 
 
+class ObjectCreateTest(TestCase):
+    def test_create_empty(self):
+        # Regression for #204. Smoke tests
+        candidate = Candidate()  # noqa
+        office = Office()  # noqa
+        office_election = OfficeElection()  # noqa
+
+
 class OfficeElectionTest(TestCase):
+
     def test_create_candidate(self):
         """
         Candidates have extra logic in their initializer. Play with it.

--- a/ballot/tests/test_referendum.py
+++ b/ballot/tests/test_referendum.py
@@ -4,6 +4,12 @@ from ballot.models import Ballot, Referendum, ReferendumSelection
 from locality.models import City, State
 
 
+class ObjectCreateTest(TestCase):
+    def test_create_empty(self):
+        referendum = Referendum()  # noqa
+        referendum_selection = ReferendumSelection()  # noqa
+
+
 class ReferendumTest(TestCase):
     def test_create_candidate(self):
         """


### PR DESCRIPTION
The constructor for `Candidate` assumed too much. The constructor for `OfficeElection` had some old code in there.

Added tests, and tested manually in the admin.
