### PR TITLE
WIP: add generic_dedupe module for tracking dedupe changes.

### DIFF
--- a/disclosure/settings.py
+++ b/disclosure/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
     'calaccess_raw',
     'netfile_raw',
     'zipcode_metro_raw',
+    'generic_dedupe',
     'locality',  # dep: none
     'ballot',  # dep: locality
     'finance',  # dep: locality, ballot

--- a/generic_dedupe/__init__.py
+++ b/generic_dedupe/__init__.py
@@ -1,0 +1,3 @@
+from .models import DedupeMixin
+from .signals import add_dedupe_signals
+__all__ = ['add_dedupe_signals', 'DedupeMixin']

--- a/generic_dedupe/admin.py
+++ b/generic_dedupe/admin.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+from .forms import DedupeForm
+from . import models
+
+admin.site.register(models.DedupeLogEntry)
+
+
+class DedupeAdmin(admin.ModelAdmin):
+    """Adds a dropdown for selecting the 'true model'."""
+    form = DedupeForm
+
+    class Meta:
+        fields = '__all__'

--- a/generic_dedupe/forms.py
+++ b/generic_dedupe/forms.py
@@ -1,0 +1,35 @@
+from django import forms
+
+from .models import DedupeMixin
+
+
+class DedupeForm(forms.ModelForm):
+    """Adds a dropdown for the 'true model'."""
+    true_model = forms.ModelChoiceField(queryset=None, required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(DedupeForm, self).__init__(*args, **kwargs)
+        # Available values are of the same class as the model this form
+        # is registered to.
+        #
+        # Use filtered_objects to limit values only to non-deduped values.
+        self.fields['true_model'].queryset = self.Meta.model.filtered_objects.all()
+        if 'instance' in kwargs:
+            # If there's an instance, set the default value to
+            # the current value of that model's "true model ID"
+            instance = kwargs['instance']
+            true_model_id = instance.true_model_id
+            if true_model_id is not None:
+                self.fields['true_model'].initial = true_model_id
+
+    def save(self, commit=True):
+        """Set the result onto the model."""
+        model = super(DedupeForm, self).save(commit=False)
+        true_model = self.cleaned_data.get('true_model', None)
+        model.true_model_id = getattr(true_model, 'id', None)
+        return model
+
+    class Meta:
+        model = DedupeMixin
+        fields = '__all__'
+        exclude = ('true_model_id',)  # Don't show the raw integer field.

--- a/generic_dedupe/migrations/0001_initial.py
+++ b/generic_dedupe/migrations/0001_initial.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('admin', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DedupeLogEntry',
+            fields=[
+                ('logentry_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='admin.LogEntry')),
+                ('class_name', models.CharField(max_length=1024)),
+                ('prop_name', models.CharField(max_length=1024)),
+                ('true_model_id', models.IntegerField()),
+                ('old_true_model_id', models.IntegerField(default=None, null=True, blank=True)),
+            ],
+            bases=('admin.logentry',),
+        ),
+    ]

--- a/generic_dedupe/models.py
+++ b/generic_dedupe/models.py
@@ -1,0 +1,49 @@
+from django.contrib.admin.models import LogEntry
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+
+class DedupeManager(models.Manager):
+    """Hide corrected models."""
+    def get_queryset(self):
+        return super(DedupeManager, self).get_queryset().filter(true_model_id=None)
+
+
+class DedupeMixin(models.Model):
+    """
+    Adds the 'true_model_id' integer field, and swaps out managers.
+    """
+    objects = models.Manager()
+    filtered_objects = DedupeManager()
+    true_model_id = models.IntegerField(default=None, blank=True, null=True)
+
+    class Meta:
+        abstract = True
+
+
+@python_2_unicode_compatible
+class DedupeLogEntry(LogEntry):
+    """
+    Log for deduped items.
+
+    This is both for keeping records of what happens, as well as
+    allowing us to undo deduping.
+    """
+    class_name = models.CharField(max_length=1024)
+    prop_name = models.CharField(max_length=1024)
+    true_model_id = models.IntegerField()
+    old_true_model_id = models.IntegerField(default=None, blank=True, null=True)
+
+    def save(self, *args, **kwargs):
+        """Add a default meaningful change_message."""
+        if not self.change_message:
+            self.change_message = "Changed %s.%s for %s from %d to %d" % (
+                self.class_name, self.prop_name, self.object_repr,
+                self.old_true_model_id, self.true_model_id)
+        super(DedupeLogEntry, self).save(*args, **kwargs)
+
+    def __str__(self):
+        return self.change_message
+
+    class Meta:
+        app_label = 'generic_dedupe'

--- a/generic_dedupe/signals.py
+++ b/generic_dedupe/signals.py
@@ -52,19 +52,18 @@ def revert_dedupe(sender, instance, **kwargs):
                 #
                 # Otherwise, this is just an actual direct entry
                 #   for the true model.
-                try:
-                    from .models import DedupeLogEntry
-                    log_entry = DedupeLogEntry.objects.get(
-                        object_id=obj.pk,
-                        old_true_model_id=instance.id, true_model_id=tm.id,
-                        class_name=obj.__class__.__name__,
-                        prop_name=relationship.field.name)
-                except DedupeLogEntry.DoesNotExist:
+                from .models import DedupeLogEntry
+                log_entries = DedupeLogEntry.objects.filter(
+                    object_id=obj.pk,
+                    old_true_model_id=instance.id, true_model_id=tm.id,
+                    class_name=obj.__class__.__name__,
+                    prop_name=relationship.field.name)
+                if log_entries.count() == 0:
                     # print("No matching log entry for %s" % obj)
                     continue
                 else:
                     # print("Need to revert for %s" % obj)
-                    log_entry.delete()
+                    log_entries.delete()
 
                 # Reset the attribute to the original value--this model instance.
                 setattr(obj, relationship.field.name, instance)

--- a/generic_dedupe/signals.py
+++ b/generic_dedupe/signals.py
@@ -85,7 +85,7 @@ def apply_dedupe(sender, instance, **kwargs):
                     user, _ = User.objects.get_or_create(username='DedupeUser')
                     from .models import DedupeLogEntry
                     log_entry = DedupeLogEntry(
-                        object_id=obj.pk, object_repr=str(obj), action_flag=ADDITION,
+                        object_id=obj.pk, object_repr=str(obj)[:200], action_flag=ADDITION,
                         content_type_id=ContentType.objects.get_for_model(obj).pk,
                         user_id=user.id,
                         true_model_id=tm.id,

--- a/generic_dedupe/signals.py
+++ b/generic_dedupe/signals.py
@@ -1,0 +1,111 @@
+from django.contrib.auth.models import User
+from django.contrib.admin.models import ADDITION
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.db.models.signals import pre_save, post_save, pre_delete
+from django.dispatch import receiver
+
+
+def model_and_supers(model):
+    """Return an iterator containing the model and it's superclass versions."""
+    if model is None:
+        return
+    yield model
+    for cls in model._meta.get_parent_list():
+        yield cls.objects.get(id=model.id)
+
+
+def get_related_queryset(model, relationship):
+    """Drills into relationship to pull out related models."""
+    if relationship.one_to_one:
+        return []
+
+    attr = relationship.get_accessor_name()
+    attr_val = getattr(model, attr, None)
+    queryset = attr_val.get_queryset() if attr_val else []
+    return queryset
+
+
+@transaction.atomic
+def revert_dedupe(sender, instance, **kwargs):
+    """
+    Pre-save: if true_model was previously set, revert all foregn
+    keys to point back to the actual model.
+    """
+    # Get the model as it was before save.
+    try:
+        old_model = sender.objects.get(id=instance.id)
+    except sender.DoesNotExist:
+        return
+    else:
+        if old_model.true_model_id is None:
+            return
+
+    true_model = sender.objects.get(id=old_model.true_model_id)
+
+    # Loop through foreign key relationships.
+    for tm in model_and_supers(true_model):
+        for relationship in tm._meta.related_objects:
+            for obj in get_related_queryset(tm, relationship):
+                # Make sure there's a log entry setting the
+                # true_model_id to true_model on this object.
+                #
+                # Otherwise, this is just an actual direct entry
+                #   for the true model.
+                try:
+                    from .models import DedupeLogEntry
+                    log_entry = DedupeLogEntry.objects.get(
+                        object_id=obj.pk,
+                        old_true_model_id=instance.id, true_model_id=tm.id,
+                        class_name=obj.__class__.__name__,
+                        prop_name=relationship.field.name)
+                except DedupeLogEntry.DoesNotExist:
+                    # print("No matching log entry for %s" % obj)
+                    continue
+                else:
+                    # print("Need to revert for %s" % obj)
+                    log_entry.delete()
+
+                # Reset the attribute to the original value--this model instance.
+                setattr(obj, relationship.field.name, instance)
+                obj.save()
+
+    return instance
+
+
+@transaction.atomic
+def apply_dedupe(sender, instance, **kwargs):
+    """Post-save: set up any new."""
+    if instance.true_model_id is not None:
+        true_model = sender.objects.get(id=instance.true_model_id)
+        for inst, tm in zip(model_and_supers(instance), model_and_supers(true_model)):
+            # Migrate any foreign keys from the instance to the true_model
+            for relationship in inst._meta.related_objects:
+                for obj in get_related_queryset(inst, relationship):
+                    # Add a log entry, for an auto-created user.
+                    user, _ = User.objects.get_or_create(username='DedupeUser')
+                    from .models import DedupeLogEntry
+                    log_entry = DedupeLogEntry(
+                        object_id=obj.pk, object_repr=str(obj), action_flag=ADDITION,
+                        content_type_id=ContentType.objects.get_for_model(obj).pk,
+                        user_id=user.id,
+                        true_model_id=tm.id,
+                        old_true_model_id=getattr(obj, relationship.field.name).id,
+                        class_name=obj.__class__.__name__,
+                        prop_name=relationship.field.name)
+                    log_entry.save()
+
+                    # Set the actual data; must be done after log as the logging
+                    # assumes this value is the old value.
+                    setattr(obj, relationship.field.name, tm)
+                    obj.save()
+
+    return instance
+
+
+def add_dedupe_signals(cls):
+    """Class decorator to add signals needed to dedupe."""
+    receiver(pre_save, sender=cls)(revert_dedupe)
+    receiver(post_save, sender=cls)(apply_dedupe)
+    receiver(pre_delete, sender=cls)(revert_dedupe)
+    return cls

--- a/locality/admin.py
+++ b/locality/admin.py
@@ -1,8 +1,10 @@
 from django.contrib import admin
 
 from . import models
+from generic_dedupe.admin import DedupeAdmin
 
-admin.site.register(models.City)
+
+admin.site.register(models.City, DedupeAdmin)
 admin.site.register(models.County)
 admin.site.register(models.State)
 admin.site.register(models.ZipCode)

--- a/locality/migrations/0002_locality_true_model_id.py
+++ b/locality/migrations/0002_locality_true_model_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locality', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='locality',
+            name='true_model_id',
+            field=models.IntegerField(default=None, null=True, blank=True),
+        ),
+    ]

--- a/locality/models.py
+++ b/locality/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.db.models.fields.related import OneToOneRel
 from django.utils.encoding import python_2_unicode_compatible
 
+from generic_dedupe import add_dedupe_signals, DedupeMixin
+
 
 class ReverseLookupStringMixin(object):
     def reverse_lookup(self):
@@ -22,7 +24,8 @@ class ReverseLookupStringMixin(object):
 
 
 @python_2_unicode_compatible
-class Locality(models.Model, ReverseLookupStringMixin):
+@add_dedupe_signals
+class Locality(DedupeMixin, ReverseLookupStringMixin):
     """
     A base table that gives a globally unique ID to any
     location (city, state, etc)
@@ -50,6 +53,7 @@ class FipsMixin(Locality):
 
 
 @python_2_unicode_compatible
+@add_dedupe_signals
 class City(FipsMixin):
     """
     City


### PR DESCRIPTION
To do:
- [ ] Unit tests

This is an alternate approach to https://github.com/caciviclab/disclosure-backend/pull/201 - tracking deduping, allowing manual deduping through the admin interface, and making deduping reversible.

The approach here is:
- Add a `true_model_id` field for any entry that can be deduped.
- When `true_model_id` is set, all foreign keys onto that model are automagically migrated to the "true model", and a `DedupeLogEntry` is added for each foreign key that was changed.
- If `true_model_id` is changed, then the old `DedupeLogEntry` values are used to revert to the original model, and the new `true_model_id` is applied.

I've tested this manually and it seems to work (set / reset / unset). I will work on unit tests, but I wanted to get a basic version out there for discussion first.

The code isn't huge, but it's complicated and likely incomplete. The goal here is to start with an MVP that works for our core use-cases.

The models used in this code are:
- `DedupeMixin` - adds the `true_model_id` field and provides a `filtered_objects` manager that gives a list of rows that are core data / not unwanted variants.
- `DedupeLogEntry` - extends `LogEntry` and keeps track of info to make dedupe reversible.

Finally, some screen shots:

Setting "true model" to an alternate city:
![image](https://cloud.githubusercontent.com/assets/4072455/13205373/a1280648-d89b-11e5-9758-9b208af12c6b.png)

Dedupe log entries auto-created, showing the foreign keys set by the above manual setting.
![image](https://cloud.githubusercontent.com/assets/4072455/13205379/bfc4d694-d89b-11e5-96dd-81b78f4e4c2a.png)

Unset the "true model", and ...
![image](https://cloud.githubusercontent.com/assets/4072455/13205388/d57165c0-d89b-11e5-884b-47d387e768c6.png)

The foreign keys are reset (not shown here), and the log entries are deleted:
![image](https://cloud.githubusercontent.com/assets/4072455/13205389/dd78225e-d89b-11e5-9dc9-e4f4b243a0fb.png)
