### PR TITLE
BF: #192: ZipCode doesn't belong in Locality.

### DIFF
--- a/locality/models.py
+++ b/locality/models.py
@@ -94,10 +94,13 @@ class State(FipsMixin):
 
 
 @python_2_unicode_compatible
-class ZipCode(Locality):
+class ZipCode(models.Model):
     """
     A Static set of ZIP code to "metro" name mappings.
     """
+    name = models.CharField(max_length=128, blank=True, null=True, default=None)
+    short_name = models.CharField(max_length=32, blank=True, null=True, default=None)
+
     city = models.ForeignKey('City', blank=True, null=True, default=None)
     county = models.ForeignKey('County', blank=True, null=True, default=None)
     state = models.ForeignKey('State', blank=True, null=True, default=None)


### PR DESCRIPTION
I couldn't think of a good reason for `ZipCode` to be a subclass of `Locality`. They are different kinds of things--`ZipCode` is a postal thing, other `Locality` types are ballot-ish.

So rather than filter out `ZipCode` for Locality, I just separated the two here.
