### PR TITLE
ENH: add 'make clean' to remove pyc files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ run:
 	python manage.py runserver
 
 test:
+	make clean
 	flake8 . --exclude cron,migrations,wsgi.py,settings_local.py,env
 	coverage run --source='.' manage.py test
+
+clean:
+	find . -name \*.pyc -exec rm \{\} \;
 
 .PHONY: build run test


### PR DESCRIPTION
Add a simple `clean` target to the `Makefile`, that removes `pyc` files.
