### PR TITLE
ENH: Add setuptestserver command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ We're going to create an environment with Python 2.7.9 for the project
   Change the password field to the password you chose when you installed MySQL.
 
 
-3. Run the database migration scripts
+3. Run the server setup script
   ```
-  python manage.py migrate
-  python manage.py migrate --database calaccess_raw
+  python manage.py setuptestserver
   ```
+
+  This will run database migrations, add a superuser (username: `admin`, password: `admin`),
+  and other setup steps.
 
   OSX: If you get the following error `django.core.exceptions.ImproperlyConfigured: Error loading MySQLdb module: dlopen(_mysql.so, 2): Library not loaded: libssl.1.0.0.dylib`
 
@@ -159,7 +161,6 @@ python manage.py downloadcalaccessrawdata
 To run for the purposes of development, accessing Django's admin interface:
 
 ```
-python manage.py createsuperuser  # create a username/password for yourself
 python manage.py runserver
 ```
 

--- a/disclosure/management/commands/setuptestserver.py
+++ b/disclosure/management/commands/setuptestserver.py
@@ -1,0 +1,37 @@
+from optparse import make_option
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+
+
+custom_options = (
+    make_option(
+        "--username",
+        action="store",
+        dest="username",
+        default='admin',
+        help="Admin username"
+    ),
+    make_option(
+        "--password",
+        action="store",
+        dest="password",
+        default='admin',
+        help="Admin password"
+    ),
+)
+
+
+class Command(BaseCommand):
+    help = 'Set up the test server'
+    option_list = custom_options
+
+    def handle(self, *args, **options):
+        call_command('migrate')
+        call_command('migrate', database='calaccess_raw')
+
+        if User.objects.filter(username=options['username']).count() == 0:
+            print("Adding superuser '%s'" % options['username'])
+            User.objects.create_superuser(
+                username=options['username'], password=options['password'], email='')

--- a/disclosure/tests/test_setuptestserver.py
+++ b/disclosure/tests/test_setuptestserver.py
@@ -1,0 +1,12 @@
+from django.core.management import call_command
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class TestServerSetupTest(TestCase):
+
+    def test_generate_calaccess_model_docs(self):
+        """ Test setuptestserver"""
+        call_command('setuptestserver')
+        # Didn't throw; check some minimum level of output.
+        self.assertTrue(User.objects.get(username="admin").username, "admin")


### PR DESCRIPTION
Add a command to deal with test server setup. All it does right now is:
- Do database migrations
- Add a superuser.

This takes 2-3 steps (and possibly more in the future) and condenses them down to one. It also makes the documentation and setup simpler for non-Django (read: frontend) users.
