### PR TITLE
add resolve_other command to show how other maps to known Employers.

### DIFF
--- a/finance/management/commands/resolve_other.py
+++ b/finance/management/commands/resolve_other.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from ...models import Employer, OtherBenefactor
+
+
+class Command(BaseCommand):
+    help = 'Set up the test server'
+    # option_list = custom_options
+
+    def handle(self, *args, **options):
+        for committee in OtherBenefactor.objects.all():
+            employers = Employer.objects.filter(name__iexact=committee.name)
+            if employers.count() == 0:
+                continue
+
+            print(committee, employers[0])


### PR DESCRIPTION
Title says it all. This can be useful if we want to try and create this mapping later.

Sample output of the command shows matches between "other" benefactors and known employers:

```
disclosure-backend $ python manage.py resolve_other

(<OtherBenefactor: 5th Avenue Insurance>, <Employer: 5th Avenue Insurance>)
(<OtherBenefactor: Ab&i>, <Employer: Ab&i>)
(<OtherBenefactor: Adams Nye Becht Llp>, <Employer: Adams Nye Becht Llp>)
(<OtherBenefactor: Admiral Property Company>, <Employer: Admiral Property Company>)
(<OtherBenefactor: Atlas Hotels>, <Employer: Atlas Hotels>)
(<OtherBenefactor: Bay Alarm>, <Employer: Bay Alarm>)
(<OtherBenefactor: Bergelectric>, <Employer: Bergelectric>)
(<OtherBenefactor: Bergelectric Corp>, <Employer: Bergelectric Corp>)
(<OtherBenefactor: Best Bay Apartments>, <Employer: Best Bay Apartments>)
(<OtherBenefactor: Binger Communications Inc>, <Employer: Binger Communications Inc>)
(<OtherBenefactor: California Marine Cleaning, Inc.>, <Employer: California Marine Cleaning, Inc.>)
(<OtherBenefactor: Carleton Management, Inc.>, <Employer: Carleton Management, Inc.>)
(<OtherBenefactor: Carrier Johnson>, <Employer: Carrier Johnson>)
(<OtherBenefactor: Dealy Development Inc.>, <Employer: Dealy Development Inc.>)
(<OtherBenefactor: Economy Lumber>, <Employer: Economy Lumber>)
(<OtherBenefactor: Finao Investments>, <Employer: Finao Investments>)
(<OtherBenefactor: Green Nectar>, <Employer: Green Nectar>)
(<OtherBenefactor: Hensel Phelps Construction Co.>, <Employer: Hensel Phelps Construction Co.>)
(<OtherBenefactor: Hotel Managers Group Llc>, <Employer: Hotel Managers Group Llc>)

...
```
