### PR TITLE
BF: #238: Swap Locality for City to get "type" out in /locality/search.

### DIFF
--- a/disclosure/views.py
+++ b/disclosure/views.py
@@ -14,7 +14,7 @@ from .serializers import BeneficiaryMoneyReceivedSerializer
 from ballot.models import Ballot, BallotItemSelection
 from finance.models import Beneficiary, IndependentMoney
 from finance.views import summarize_money
-from locality.models import City, Locality
+from locality.models import Locality
 from locality.serializers import LocalitySerializer
 from swagger_nickname_registry import swagger_nickname
 
@@ -36,7 +36,7 @@ def search_view(request):
         LocalitySerializer
     """
     query = request.query_params.get('q', '')
-    query_set = City.objects.filter(~Q(ballot=None), name__icontains=query)
+    query_set = Locality.objects.filter(~Q(ballot=None), name__icontains=query)
     serializer = LocalitySerializer(query_set, many=True)
     return Response(serializer.data)
 


### PR DESCRIPTION
Fix for #238. Bug was due to sending a `City` object to the `LocalitySerializer`. `Locality` has a `type` property; `City` does not.

Change is simple: just query on `Locality` instead of `City`. Since we limit query results based on having ballot data available, no need to limit by object type.

It works:
![image](https://cloud.githubusercontent.com/assets/4072455/14947254/2361a35a-0fe5-11e6-877d-73ac42db6e8f.png)
