### PR TITLE
Add missing fixture data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.pyc
 
 # Data
-data/calaccess
-data/netfile
+/data/
 
 # Django
 settings_local.py

--- a/disclosure/fixtures/2016_05_02_locality.json
+++ b/disclosure/fixtures/2016_05_02_locality.json
@@ -1,1 +1,28001 @@
-[{"fields": {"true_model_id": null, "name": "California", "short_name": "CA"}, "model": "locality.locality", "pk": 1}, {"fields": {"true_model_id": null, "name": "San Diego", "short_name": "CSD"}, "model": "locality.locality", "pk": 2}, {"fields": {"true_model_id": null, "name": "El Cajon", "short_name": null}, "model": "locality.locality", "pk": 3}, {"fields": {"true_model_id": null, "name": null, "short_name": "AZ"}, "model": "locality.locality", "pk": 4}, {"fields": {"true_model_id": null, "name": "Phoenix", "short_name": null}, "model": "locality.locality", "pk": 5}, {"fields": {"true_model_id": null, "name": "La Jolla", "short_name": null}, "model": "locality.locality", "pk": 6}, {"fields": {"true_model_id": null, "name": "Brea", "short_name": null}, "model": "locality.locality", "pk": 7}, {"fields": {"true_model_id": null, "name": "Solana Beach", "short_name": null}, "model": "locality.locality", "pk": 8}, {"fields": {"true_model_id": null, "name": "San Francisco", "short_name": null}, "model": "locality.locality", "pk": 9}, {"fields": {"true_model_id": null, "name": null, "short_name": "CO"}, "model": "locality.locality", "pk": 10}, {"fields": {"true_model_id": null, "name": "Greenwood Village", "short_name": null}, "model": "locality.locality", "pk": 11}, {"fields": {"true_model_id": null, "name": null, "short_name": "MI"}, "model": "locality.locality", "pk": 12}, {"fields": {"true_model_id": null, "name": "Mason", "short_name": null}, "model": "locality.locality", "pk": 13}, {"fields": {"true_model_id": null, "name": "Sacramento", "short_name": null}, "model": "locality.locality", "pk": 14}, {"fields": {"true_model_id": null, "name": "Los Angeles", "short_name": null}, "model": "locality.locality", "pk": 15}, {"fields": {"true_model_id": null, "name": "Lemon Grove", "short_name": null}, "model": "locality.locality", "pk": 16}, {"fields": {"true_model_id": null, "name": "La Mesa", "short_name": null}, "model": "locality.locality", "pk": 17}, {"fields": {"true_model_id": null, "name": null, "short_name": "IL"}, "model": "locality.locality", "pk": 18}, {"fields": {"true_model_id": null, "name": "Chicago", "short_name": null}, "model": "locality.locality", "pk": 19}, {"fields": {"true_model_id": null, "name": "Encinitas", "short_name": null}, "model": "locality.locality", "pk": 20}, {"fields": {"true_model_id": null, "name": "San Ramon", "short_name": null}, "model": "locality.locality", "pk": 21}, {"fields": {"true_model_id": null, "name": "Escondido", "short_name": null}, "model": "locality.locality", "pk": 22}, {"fields": {"true_model_id": null, "name": "Carlsbad", "short_name": null}, "model": "locality.locality", "pk": 23}, {"fields": {"true_model_id": null, "name": "Rancho Santa Fe", "short_name": null}, "model": "locality.locality", "pk": 24}, {"fields": {"true_model_id": null, "name": "Riverside", "short_name": null}, "model": "locality.locality", "pk": 25}, {"fields": {"true_model_id": null, "name": "Poway", "short_name": null}, "model": "locality.locality", "pk": 26}, {"fields": {"true_model_id": null, "name": "Orange", "short_name": null}, "model": "locality.locality", "pk": 27}, {"fields": {"true_model_id": null, "name": "Temecula", "short_name": null}, "model": "locality.locality", "pk": 28}, {"fields": {"true_model_id": null, "name": "Jamul", "short_name": null}, "model": "locality.locality", "pk": 29}, {"fields": {"true_model_id": null, "name": null, "short_name": "Unknown-State"}, "model": "locality.locality", "pk": 30}, {"fields": {"true_model_id": null, "name": "Unknown-City", "short_name": null}, "model": "locality.locality", "pk": 31}, {"fields": {"true_model_id": null, "name": "Coronado", "short_name": null}, "model": "locality.locality", "pk": 32}, {"fields": {"true_model_id": null, "name": "Del Mar", "short_name": null}, "model": "locality.locality", "pk": 33}, {"fields": {"true_model_id": null, "name": "San Marcos", "short_name": null}, "model": "locality.locality", "pk": 34}, {"fields": {"true_model_id": null, "name": "Spring Valley", "short_name": null}, "model": "locality.locality", "pk": 35}, {"fields": {"true_model_id": null, "name": "Vista", "short_name": null}, "model": "locality.locality", "pk": 36}, {"fields": {"true_model_id": null, "name": "South San Francisco", "short_name": null}, "model": "locality.locality", "pk": 37}, {"fields": {"true_model_id": null, "name": "Alamo", "short_name": null}, "model": "locality.locality", "pk": 38}, {"fields": {"true_model_id": null, "name": "Alpine", "short_name": null}, "model": "locality.locality", "pk": 39}, {"fields": {"true_model_id": null, "name": "Colorado Springs", "short_name": null}, "model": "locality.locality", "pk": 40}, {"fields": {"true_model_id": null, "name": null, "short_name": "MD"}, "model": "locality.locality", "pk": 41}, {"fields": {"true_model_id": null, "name": "Bethesda", "short_name": null}, "model": "locality.locality", "pk": 42}, {"fields": {"true_model_id": null, "name": "Murrieta", "short_name": null}, "model": "locality.locality", "pk": 43}, {"fields": {"true_model_id": null, "name": "Bonita", "short_name": null}, "model": "locality.locality", "pk": 44}, {"fields": {"true_model_id": null, "name": "Irvine", "short_name": null}, "model": "locality.locality", "pk": 45}, {"fields": {"true_model_id": null, "name": "Lakeside", "short_name": null}, "model": "locality.locality", "pk": 46}, {"fields": {"true_model_id": null, "name": "Huntington Beach", "short_name": null}, "model": "locality.locality", "pk": 47}, {"fields": {"true_model_id": null, "name": "Wildomar", "short_name": null}, "model": "locality.locality", "pk": 48}, {"fields": {"true_model_id": null, "name": "Newport Beach", "short_name": null}, "model": "locality.locality", "pk": 49}, {"fields": {"true_model_id": null, "name": "Marina Del Rey", "short_name": null}, "model": "locality.locality", "pk": 50}, {"fields": {"true_model_id": null, "name": null, "short_name": "DC"}, "model": "locality.locality", "pk": 51}, {"fields": {"true_model_id": null, "name": "Washington", "short_name": null}, "model": "locality.locality", "pk": 52}, {"fields": {"true_model_id": null, "name": null, "short_name": "NC"}, "model": "locality.locality", "pk": 53}, {"fields": {"true_model_id": null, "name": "Charlotte", "short_name": null}, "model": "locality.locality", "pk": 54}, {"fields": {"true_model_id": null, "name": "Cardiff By The Sea", "short_name": null}, "model": "locality.locality", "pk": 55}, {"fields": {"true_model_id": null, "name": "Aspen", "short_name": null}, "model": "locality.locality", "pk": 56}, {"fields": {"true_model_id": null, "name": "Ladra Ranch", "short_name": null}, "model": "locality.locality", "pk": 57}, {"fields": {"true_model_id": null, "name": null, "short_name": "MA"}, "model": "locality.locality", "pk": 58}, {"fields": {"true_model_id": null, "name": "Boston", "short_name": null}, "model": "locality.locality", "pk": 59}, {"fields": {"true_model_id": null, "name": "Cupertino", "short_name": null}, "model": "locality.locality", "pk": 60}, {"fields": {"true_model_id": null, "name": null, "short_name": "PA"}, "model": "locality.locality", "pk": 61}, {"fields": {"true_model_id": null, "name": "Johnstown", "short_name": null}, "model": "locality.locality", "pk": 62}, {"fields": {"true_model_id": null, "name": "Valley Center", "short_name": null}, "model": "locality.locality", "pk": 63}, {"fields": {"true_model_id": null, "name": "Ramona", "short_name": null}, "model": "locality.locality", "pk": 64}, {"fields": {"true_model_id": null, "name": "Cottonwood", "short_name": null}, "model": "locality.locality", "pk": 65}, {"fields": {"true_model_id": null, "name": null, "short_name": "MO"}, "model": "locality.locality", "pk": 66}, {"fields": {"true_model_id": null, "name": "St. Louis", "short_name": null}, "model": "locality.locality", "pk": 67}, {"fields": {"true_model_id": null, "name": null, "short_name": "VA"}, "model": "locality.locality", "pk": 68}, {"fields": {"true_model_id": null, "name": "Williamsburg", "short_name": null}, "model": "locality.locality", "pk": 69}, {"fields": {"true_model_id": null, "name": "Diamond Bar", "short_name": null}, "model": "locality.locality", "pk": 70}, {"fields": {"true_model_id": null, "name": "Oceanside", "short_name": null}, "model": "locality.locality", "pk": 71}, {"fields": {"true_model_id": null, "name": "Chula Vista", "short_name": null}, "model": "locality.locality", "pk": 72}, {"fields": {"true_model_id": null, "name": null, "short_name": "NV"}, "model": "locality.locality", "pk": 73}, {"fields": {"true_model_id": null, "name": "Las Vegas", "short_name": null}, "model": "locality.locality", "pk": 74}, {"fields": {"true_model_id": null, "name": "Beverly Hills", "short_name": null}, "model": "locality.locality", "pk": 75}, {"fields": {"true_model_id": null, "name": null, "short_name": "NY"}, "model": "locality.locality", "pk": 76}, {"fields": {"true_model_id": null, "name": "New York", "short_name": null}, "model": "locality.locality", "pk": 77}, {"fields": {"true_model_id": null, "name": "Pasadena", "short_name": null}, "model": "locality.locality", "pk": 78}, {"fields": {"true_model_id": null, "name": null, "short_name": "TX"}, "model": "locality.locality", "pk": 79}, {"fields": {"true_model_id": null, "name": "Driftwood", "short_name": null}, "model": "locality.locality", "pk": 80}, {"fields": {"true_model_id": null, "name": "Santee", "short_name": null}, "model": "locality.locality", "pk": 81}, {"fields": {"true_model_id": null, "name": "Yorba Linda", "short_name": null}, "model": "locality.locality", "pk": 82}, {"fields": {"true_model_id": null, "name": "Laguna Niguel", "short_name": null}, "model": "locality.locality", "pk": 83}, {"fields": {"true_model_id": null, "name": "Tustin", "short_name": null}, "model": "locality.locality", "pk": 84}, {"fields": {"true_model_id": null, "name": null, "short_name": "WY"}, "model": "locality.locality", "pk": 85}, {"fields": {"true_model_id": null, "name": "Cody", "short_name": null}, "model": "locality.locality", "pk": 86}, {"fields": {"true_model_id": null, "name": null, "short_name": "FL"}, "model": "locality.locality", "pk": 87}, {"fields": {"true_model_id": null, "name": "Merritt Island", "short_name": null}, "model": "locality.locality", "pk": 88}, {"fields": {"true_model_id": null, "name": "El Dorado Hills", "short_name": null}, "model": "locality.locality", "pk": 89}, {"fields": {"true_model_id": null, "name": "Chesapeake", "short_name": null}, "model": "locality.locality", "pk": 90}, {"fields": {"true_model_id": null, "name": "Mountain Center", "short_name": null}, "model": "locality.locality", "pk": 91}, {"fields": {"true_model_id": null, "name": "Glendale", "short_name": null}, "model": "locality.locality", "pk": 92}, {"fields": {"true_model_id": null, "name": "San Clemente", "short_name": null}, "model": "locality.locality", "pk": 93}, {"fields": {"true_model_id": null, "name": "Virginia Beach", "short_name": null}, "model": "locality.locality", "pk": 94}, {"fields": {"true_model_id": null, "name": null, "short_name": "NM"}, "model": "locality.locality", "pk": 95}, {"fields": {"true_model_id": null, "name": "Albuquerque", "short_name": null}, "model": "locality.locality", "pk": 96}, {"fields": {"true_model_id": null, "name": "Indio", "short_name": null}, "model": "locality.locality", "pk": 97}, {"fields": {"true_model_id": null, "name": "South Pasadena", "short_name": null}, "model": "locality.locality", "pk": 98}, {"fields": {"true_model_id": null, "name": null, "short_name": "ID"}, "model": "locality.locality", "pk": 99}, {"fields": {"true_model_id": null, "name": "Boise", "short_name": null}, "model": "locality.locality", "pk": 100}, {"fields": {"true_model_id": null, "name": "Big Bear Lake", "short_name": null}, "model": "locality.locality", "pk": 101}, {"fields": {"true_model_id": null, "name": null, "short_name": "WA"}, "model": "locality.locality", "pk": 102}, {"fields": {"true_model_id": null, "name": "Tacoma", "short_name": null}, "model": "locality.locality", "pk": 103}, {"fields": {"true_model_id": null, "name": "National City", "short_name": null}, "model": "locality.locality", "pk": 104}, {"fields": {"true_model_id": null, "name": "Anaheim", "short_name": null}, "model": "locality.locality", "pk": 105}, {"fields": {"true_model_id": null, "name": "Oxnard", "short_name": null}, "model": "locality.locality", "pk": 106}, {"fields": {"true_model_id": null, "name": "Boulder", "short_name": null}, "model": "locality.locality", "pk": 107}, {"fields": {"true_model_id": null, "name": "Santa Maria", "short_name": null}, "model": "locality.locality", "pk": 108}, {"fields": {"true_model_id": null, "name": "Imperial Beach", "short_name": null}, "model": "locality.locality", "pk": 109}, {"fields": {"true_model_id": null, "name": "Newport Coast", "short_name": null}, "model": "locality.locality", "pk": 110}, {"fields": {"true_model_id": null, "name": "Vienna", "short_name": null}, "model": "locality.locality", "pk": 111}, {"fields": {"true_model_id": null, "name": "Las Cruces", "short_name": null}, "model": "locality.locality", "pk": 112}, {"fields": {"true_model_id": null, "name": "Paradise Valley", "short_name": null}, "model": "locality.locality", "pk": 113}, {"fields": {"true_model_id": null, "name": "La Habra", "short_name": null}, "model": "locality.locality", "pk": 114}, {"fields": {"true_model_id": null, "name": "La Mirada", "short_name": null}, "model": "locality.locality", "pk": 115}, {"fields": {"true_model_id": null, "name": "Stafford", "short_name": null}, "model": "locality.locality", "pk": 116}, {"fields": {"true_model_id": null, "name": "Oakland", "short_name": "COAK"}, "model": "locality.locality", "pk": 117}, {"fields": {"true_model_id": null, "name": "Harrisburg", "short_name": null}, "model": "locality.locality", "pk": 118}, {"fields": {"true_model_id": null, "name": "Paramount", "short_name": null}, "model": "locality.locality", "pk": 119}, {"fields": {"true_model_id": null, "name": "San Mateo", "short_name": null}, "model": "locality.locality", "pk": 120}, {"fields": {"true_model_id": null, "name": "Tampa", "short_name": null}, "model": "locality.locality", "pk": 121}, {"fields": {"true_model_id": null, "name": "Whittier", "short_name": null}, "model": "locality.locality", "pk": 122}, {"fields": {"true_model_id": null, "name": "Davis", "short_name": null}, "model": "locality.locality", "pk": 123}, {"fields": {"true_model_id": null, "name": "Berkeley", "short_name": null}, "model": "locality.locality", "pk": 124}, {"fields": {"true_model_id": null, "name": "Redwood City", "short_name": null}, "model": "locality.locality", "pk": 125}, {"fields": {"true_model_id": null, "name": "Hermosa Beach", "short_name": null}, "model": "locality.locality", "pk": 126}, {"fields": {"true_model_id": null, "name": "Montebello", "short_name": null}, "model": "locality.locality", "pk": 127}, {"fields": {"true_model_id": null, "name": "Port Saint Lucie", "short_name": null}, "model": "locality.locality", "pk": 128}, {"fields": {"true_model_id": null, "name": "Studio City", "short_name": null}, "model": "locality.locality", "pk": 129}, {"fields": {"true_model_id": null, "name": "Miami Beach", "short_name": null}, "model": "locality.locality", "pk": 130}, {"fields": {"true_model_id": null, "name": "Goleta", "short_name": null}, "model": "locality.locality", "pk": 131}, {"fields": {"true_model_id": null, "name": null, "short_name": "LA"}, "model": "locality.locality", "pk": 132}, {"fields": {"true_model_id": null, "name": "New Orleans", "short_name": null}, "model": "locality.locality", "pk": 133}, {"fields": {"true_model_id": null, "name": "Santa Ana", "short_name": null}, "model": "locality.locality", "pk": 134}, {"fields": {"true_model_id": null, "name": "Lafayette", "short_name": null}, "model": "locality.locality", "pk": 135}, {"fields": {"true_model_id": null, "name": "Rock Island", "short_name": null}, "model": "locality.locality", "pk": 136}, {"fields": {"true_model_id": null, "name": "Alhambra", "short_name": null}, "model": "locality.locality", "pk": 137}, {"fields": {"true_model_id": null, "name": "Rockville", "short_name": null}, "model": "locality.locality", "pk": 138}, {"fields": {"true_model_id": null, "name": "Hayward", "short_name": null}, "model": "locality.locality", "pk": 139}, {"fields": {"true_model_id": null, "name": "Elk Grove", "short_name": null}, "model": "locality.locality", "pk": 140}, {"fields": {"true_model_id": null, "name": "Fullerton", "short_name": null}, "model": "locality.locality", "pk": 141}, {"fields": {"true_model_id": null, "name": null, "short_name": "OH"}, "model": "locality.locality", "pk": 142}, {"fields": {"true_model_id": null, "name": "Beachwood", "short_name": null}, "model": "locality.locality", "pk": 143}, {"fields": {"true_model_id": null, "name": "Lakewood", "short_name": null}, "model": "locality.locality", "pk": 144}, {"fields": {"true_model_id": null, "name": "Belvedere Tiburon", "short_name": null}, "model": "locality.locality", "pk": 145}, {"fields": {"true_model_id": null, "name": "Mountain View", "short_name": null}, "model": "locality.locality", "pk": 146}, {"fields": {"true_model_id": null, "name": "Menlo Park", "short_name": null}, "model": "locality.locality", "pk": 147}, {"fields": {"true_model_id": null, "name": "Laguna Beach", "short_name": null}, "model": "locality.locality", "pk": 148}, {"fields": {"true_model_id": null, "name": "West Sacramento", "short_name": null}, "model": "locality.locality", "pk": 149}, {"fields": {"true_model_id": null, "name": "El Segundo", "short_name": null}, "model": "locality.locality", "pk": 150}, {"fields": {"true_model_id": null, "name": "Buena Park", "short_name": null}, "model": "locality.locality", "pk": 151}, {"fields": {"true_model_id": null, "name": "Annapolis", "short_name": null}, "model": "locality.locality", "pk": 152}, {"fields": {"true_model_id": null, "name": "El Monte", "short_name": null}, "model": "locality.locality", "pk": 153}, {"fields": {"true_model_id": null, "name": "North Las Vegas", "short_name": null}, "model": "locality.locality", "pk": 154}, {"fields": {"true_model_id": null, "name": "Corona", "short_name": null}, "model": "locality.locality", "pk": 155}, {"fields": {"true_model_id": null, "name": "Long Beach", "short_name": null}, "model": "locality.locality", "pk": 156}, {"fields": {"true_model_id": null, "name": "Cerritos", "short_name": null}, "model": "locality.locality", "pk": 157}, {"fields": {"true_model_id": null, "name": "Vacaville", "short_name": null}, "model": "locality.locality", "pk": 158}, {"fields": {"true_model_id": null, "name": null, "short_name": "IN"}, "model": "locality.locality", "pk": 159}, {"fields": {"true_model_id": null, "name": "Carmel", "short_name": null}, "model": "locality.locality", "pk": 160}, {"fields": {"true_model_id": null, "name": "Lombard", "short_name": null}, "model": "locality.locality", "pk": 161}, {"fields": {"true_model_id": null, "name": null, "short_name": "GA"}, "model": "locality.locality", "pk": 162}, {"fields": {"true_model_id": null, "name": "Atlanta", "short_name": null}, "model": "locality.locality", "pk": 163}, {"fields": {"true_model_id": null, "name": "Trabuco Canyon", "short_name": null}, "model": "locality.locality", "pk": 164}, {"fields": {"true_model_id": null, "name": "Roswell", "short_name": null}, "model": "locality.locality", "pk": 165}, {"fields": {"true_model_id": null, "name": "Norfolk", "short_name": null}, "model": "locality.locality", "pk": 166}, {"fields": {"true_model_id": null, "name": "Richmond", "short_name": null}, "model": "locality.locality", "pk": 167}, {"fields": {"true_model_id": null, "name": "Seattle", "short_name": null}, "model": "locality.locality", "pk": 168}, {"fields": {"true_model_id": null, "name": null, "short_name": "XX"}, "model": "locality.locality", "pk": 169}, {"fields": {"true_model_id": null, "name": "Singapore", "short_name": null}, "model": "locality.locality", "pk": 170}, {"fields": {"true_model_id": null, "name": "Solano Beach", "short_name": null}, "model": "locality.locality", "pk": 171}, {"fields": {"true_model_id": null, "name": null, "short_name": "HI"}, "model": "locality.locality", "pk": 172}, {"fields": {"true_model_id": null, "name": "Aiea", "short_name": null}, "model": "locality.locality", "pk": 173}, {"fields": {"true_model_id": null, "name": "Arlington", "short_name": null}, "model": "locality.locality", "pk": 174}, {"fields": {"true_model_id": null, "name": "Newcastle", "short_name": null}, "model": "locality.locality", "pk": 175}, {"fields": {"true_model_id": null, "name": "Yucca Valley", "short_name": null}, "model": "locality.locality", "pk": 176}, {"fields": {"true_model_id": null, "name": "Barrington Hills", "short_name": null}, "model": "locality.locality", "pk": 177}, {"fields": {"true_model_id": null, "name": "San Gabriel", "short_name": null}, "model": "locality.locality", "pk": 178}, {"fields": {"true_model_id": null, "name": "Fallbrook", "short_name": null}, "model": "locality.locality", "pk": 179}, {"fields": {"true_model_id": null, "name": "Herndon", "short_name": null}, "model": "locality.locality", "pk": 180}, {"fields": {"true_model_id": null, "name": null, "short_name": "NE"}, "model": "locality.locality", "pk": 181}, {"fields": {"true_model_id": null, "name": "Omaha", "short_name": null}, "model": "locality.locality", "pk": 182}, {"fields": {"true_model_id": null, "name": "Winter Park", "short_name": null}, "model": "locality.locality", "pk": 183}, {"fields": {"true_model_id": null, "name": "Orlando", "short_name": null}, "model": "locality.locality", "pk": 184}, {"fields": {"true_model_id": null, "name": "Kissimmee", "short_name": null}, "model": "locality.locality", "pk": 185}, {"fields": {"true_model_id": null, "name": "Dallas", "short_name": null}, "model": "locality.locality", "pk": 186}, {"fields": {"true_model_id": null, "name": "Torrance", "short_name": null}, "model": "locality.locality", "pk": 187}, {"fields": {"true_model_id": null, "name": "Englewood", "short_name": null}, "model": "locality.locality", "pk": 188}, {"fields": {"true_model_id": null, "name": "Irving", "short_name": null}, "model": "locality.locality", "pk": 189}, {"fields": {"true_model_id": null, "name": null, "short_name": "SC"}, "model": "locality.locality", "pk": 190}, {"fields": {"true_model_id": null, "name": "Hartsville", "short_name": null}, "model": "locality.locality", "pk": 191}, {"fields": {"true_model_id": null, "name": null, "short_name": "AR"}, "model": "locality.locality", "pk": 192}, {"fields": {"true_model_id": null, "name": "Bentonville", "short_name": null}, "model": "locality.locality", "pk": 193}, {"fields": {"true_model_id": null, "name": "Ontario", "short_name": null}, "model": "locality.locality", "pk": 194}, {"fields": {"true_model_id": null, "name": "Palomar Mountain", "short_name": null}, "model": "locality.locality", "pk": 195}, {"fields": {"true_model_id": null, "name": "San Juan Capistrano", "short_name": null}, "model": "locality.locality", "pk": 196}, {"fields": {"true_model_id": null, "name": "Winchester", "short_name": null}, "model": "locality.locality", "pk": 197}, {"fields": {"true_model_id": null, "name": "Dove Canyon", "short_name": null}, "model": "locality.locality", "pk": 198}, {"fields": {"true_model_id": null, "name": "Clayton", "short_name": null}, "model": "locality.locality", "pk": 199}, {"fields": {"true_model_id": null, "name": "Palo Alto", "short_name": null}, "model": "locality.locality", "pk": 200}, {"fields": {"true_model_id": null, "name": "Las Vegas", "short_name": null}, "model": "locality.locality", "pk": 201}, {"fields": {"true_model_id": null, "name": "Dana Point", "short_name": null}, "model": "locality.locality", "pk": 202}, {"fields": {"true_model_id": null, "name": "Burbank", "short_name": null}, "model": "locality.locality", "pk": 203}, {"fields": {"true_model_id": null, "name": "San Leandro", "short_name": null}, "model": "locality.locality", "pk": 204}, {"fields": {"true_model_id": null, "name": "Sherman Oaks", "short_name": null}, "model": "locality.locality", "pk": 205}, {"fields": {"true_model_id": null, "name": "Willits", "short_name": null}, "model": "locality.locality", "pk": 206}, {"fields": {"true_model_id": null, "name": "San Ysidro", "short_name": null}, "model": "locality.locality", "pk": 207}, {"fields": {"true_model_id": null, "name": "West Hollywood", "short_name": null}, "model": "locality.locality", "pk": 208}, {"fields": {"true_model_id": null, "name": "Hollywood", "short_name": null}, "model": "locality.locality", "pk": 209}, {"fields": {"true_model_id": null, "name": "El Centro", "short_name": null}, "model": "locality.locality", "pk": 210}, {"fields": {"true_model_id": null, "name": "Scottsdale", "short_name": null}, "model": "locality.locality", "pk": 211}, {"fields": {"true_model_id": null, "name": "San Antonio", "short_name": null}, "model": "locality.locality", "pk": 212}, {"fields": {"true_model_id": null, "name": "Van Nuys", "short_name": null}, "model": "locality.locality", "pk": 213}, {"fields": {"true_model_id": null, "name": "Palm Desert", "short_name": null}, "model": "locality.locality", "pk": 214}, {"fields": {"true_model_id": null, "name": "Fort Lauderdale", "short_name": null}, "model": "locality.locality", "pk": 215}, {"fields": {"true_model_id": null, "name": "Sloughhouse", "short_name": null}, "model": "locality.locality", "pk": 216}, {"fields": {"true_model_id": null, "name": "Holtville", "short_name": null}, "model": "locality.locality", "pk": 217}, {"fields": {"true_model_id": null, "name": "Goshen", "short_name": null}, "model": "locality.locality", "pk": 218}, {"fields": {"true_model_id": null, "name": "Valley Village", "short_name": null}, "model": "locality.locality", "pk": 219}, {"fields": {"true_model_id": null, "name": "Brookline", "short_name": null}, "model": "locality.locality", "pk": 220}, {"fields": {"true_model_id": null, "name": "Reseda", "short_name": null}, "model": "locality.locality", "pk": 221}, {"fields": {"true_model_id": null, "name": "Cathedral City", "short_name": null}, "model": "locality.locality", "pk": 222}, {"fields": {"true_model_id": null, "name": "Alameda", "short_name": null}, "model": "locality.locality", "pk": 223}, {"fields": {"true_model_id": null, "name": "Santa Barbara", "short_name": null}, "model": "locality.locality", "pk": 224}, {"fields": {"true_model_id": null, "name": "San Jose", "short_name": null}, "model": "locality.locality", "pk": 225}, {"fields": {"true_model_id": null, "name": "Mercer Island", "short_name": null}, "model": "locality.locality", "pk": 226}, {"fields": {"true_model_id": null, "name": "El Sauzal", "short_name": null}, "model": "locality.locality", "pk": 227}, {"fields": {"true_model_id": null, "name": "Belmont", "short_name": null}, "model": "locality.locality", "pk": 228}, {"fields": {"true_model_id": null, "name": "Newport News", "short_name": null}, "model": "locality.locality", "pk": 229}, {"fields": {"true_model_id": null, "name": "Lucerne Valley", "short_name": null}, "model": "locality.locality", "pk": 230}, {"fields": {"true_model_id": null, "name": null, "short_name": "CT"}, "model": "locality.locality", "pk": 231}, {"fields": {"true_model_id": null, "name": "New Cannan", "short_name": null}, "model": "locality.locality", "pk": 232}, {"fields": {"true_model_id": null, "name": "Sabn Diego", "short_name": null}, "model": "locality.locality", "pk": 233}, {"fields": {"true_model_id": null, "name": "Pacific Beach", "short_name": null}, "model": "locality.locality", "pk": 234}, {"fields": {"true_model_id": null, "name": "Guilford", "short_name": null}, "model": "locality.locality", "pk": 235}, {"fields": {"true_model_id": null, "name": "Kansas City", "short_name": null}, "model": "locality.locality", "pk": 236}, {"fields": {"true_model_id": null, "name": "Brooklyn", "short_name": null}, "model": "locality.locality", "pk": 237}, {"fields": {"true_model_id": null, "name": "Pacific Palisades", "short_name": null}, "model": "locality.locality", "pk": 238}, {"fields": {"true_model_id": null, "name": "San Sdiego", "short_name": null}, "model": "locality.locality", "pk": 239}, {"fields": {"true_model_id": null, "name": "Englewood", "short_name": null}, "model": "locality.locality", "pk": 240}, {"fields": {"true_model_id": null, "name": "Pleasanton", "short_name": null}, "model": "locality.locality", "pk": 241}, {"fields": {"true_model_id": null, "name": "Venice", "short_name": null}, "model": "locality.locality", "pk": 242}, {"fields": {"true_model_id": null, "name": "Grass Valley", "short_name": null}, "model": "locality.locality", "pk": 243}, {"fields": {"true_model_id": null, "name": null, "short_name": "ZZ"}, "model": "locality.locality", "pk": 244}, {"fields": {"true_model_id": null, "name": "Unknown-City", "short_name": null}, "model": "locality.locality", "pk": 245}, {"fields": {"true_model_id": null, "name": "Barrington", "short_name": null}, "model": "locality.locality", "pk": 246}, {"fields": {"true_model_id": null, "name": "San Marino", "short_name": null}, "model": "locality.locality", "pk": 247}, {"fields": {"true_model_id": null, "name": "Little Rock", "short_name": null}, "model": "locality.locality", "pk": 248}, {"fields": {"true_model_id": null, "name": "Sausalito", "short_name": null}, "model": "locality.locality", "pk": 249}, {"fields": {"true_model_id": null, "name": "Honolulu", "short_name": null}, "model": "locality.locality", "pk": 250}, {"fields": {"true_model_id": null, "name": "Claremont", "short_name": null}, "model": "locality.locality", "pk": 251}, {"fields": {"true_model_id": null, "name": "North Hollywood", "short_name": null}, "model": "locality.locality", "pk": 252}, {"fields": {"true_model_id": null, "name": "Rcho Santa Fe", "short_name": null}, "model": "locality.locality", "pk": 253}, {"fields": {"true_model_id": null, "name": "Roxbury", "short_name": null}, "model": "locality.locality", "pk": 254}, {"fields": {"true_model_id": null, "name": "Campo", "short_name": null}, "model": "locality.locality", "pk": 255}, {"fields": {"true_model_id": null, "name": "La Quinta", "short_name": null}, "model": "locality.locality", "pk": 256}, {"fields": {"true_model_id": null, "name": "Culver City", "short_name": null}, "model": "locality.locality", "pk": 257}, {"fields": {"true_model_id": null, "name": "Ball Ground", "short_name": null}, "model": "locality.locality", "pk": 258}, {"fields": {"true_model_id": null, "name": "Tempe", "short_name": null}, "model": "locality.locality", "pk": 259}, {"fields": {"true_model_id": null, "name": "Kildeer", "short_name": null}, "model": "locality.locality", "pk": 260}, {"fields": {"true_model_id": null, "name": "Tiburon", "short_name": null}, "model": "locality.locality", "pk": 261}, {"fields": {"true_model_id": null, "name": "Corona Del Mar", "short_name": null}, "model": "locality.locality", "pk": 262}, {"fields": {"true_model_id": null, "name": "Marietta", "short_name": null}, "model": "locality.locality", "pk": 263}, {"fields": {"true_model_id": null, "name": "Camarillo", "short_name": null}, "model": "locality.locality", "pk": 264}, {"fields": {"true_model_id": null, "name": "Calabasas", "short_name": null}, "model": "locality.locality", "pk": 265}, {"fields": {"true_model_id": null, "name": "Arcadia", "short_name": null}, "model": "locality.locality", "pk": 266}, {"fields": {"true_model_id": null, "name": "Hillsborough", "short_name": null}, "model": "locality.locality", "pk": 267}, {"fields": {"true_model_id": null, "name": "Suwanee", "short_name": null}, "model": "locality.locality", "pk": 268}, {"fields": {"true_model_id": null, "name": "Eatonton", "short_name": null}, "model": "locality.locality", "pk": 269}, {"fields": {"true_model_id": null, "name": "Kahului", "short_name": null}, "model": "locality.locality", "pk": 270}, {"fields": {"true_model_id": null, "name": "Ojai", "short_name": null}, "model": "locality.locality", "pk": 271}, {"fields": {"true_model_id": null, "name": "Gardena", "short_name": null}, "model": "locality.locality", "pk": 272}, {"fields": {"true_model_id": null, "name": null, "short_name": "MN"}, "model": "locality.locality", "pk": 273}, {"fields": {"true_model_id": null, "name": "Columbia Heights", "short_name": null}, "model": "locality.locality", "pk": 274}, {"fields": {"true_model_id": null, "name": "Yarmouth Port", "short_name": null}, "model": "locality.locality", "pk": 275}, {"fields": {"true_model_id": null, "name": "Plantation", "short_name": null}, "model": "locality.locality", "pk": 276}, {"fields": {"true_model_id": null, "name": "Coto De Caza", "short_name": null}, "model": "locality.locality", "pk": 277}, {"fields": {"true_model_id": null, "name": "Rancho Cucamonga", "short_name": null}, "model": "locality.locality", "pk": 278}, {"fields": {"true_model_id": null, "name": "Incline Village", "short_name": null}, "model": "locality.locality", "pk": 279}, {"fields": {"true_model_id": null, "name": "Trabuco Canyon", "short_name": null}, "model": "locality.locality", "pk": 280}, {"fields": {"true_model_id": null, "name": null, "short_name": "WV"}, "model": "locality.locality", "pk": 281}, {"fields": {"true_model_id": null, "name": "Charleston", "short_name": null}, "model": "locality.locality", "pk": 282}, {"fields": {"true_model_id": null, "name": "Orinda", "short_name": null}, "model": "locality.locality", "pk": 283}, {"fields": {"true_model_id": null, "name": null, "short_name": "TN"}, "model": "locality.locality", "pk": 284}, {"fields": {"true_model_id": null, "name": "Franklin", "short_name": null}, "model": "locality.locality", "pk": 285}, {"fields": {"true_model_id": null, "name": "El Cerrito", "short_name": null}, "model": "locality.locality", "pk": 286}, {"fields": {"true_model_id": null, "name": "Alpharetta", "short_name": null}, "model": "locality.locality", "pk": 287}, {"fields": {"true_model_id": null, "name": "Malibu", "short_name": null}, "model": "locality.locality", "pk": 288}, {"fields": {"true_model_id": null, "name": "Kailua", "short_name": null}, "model": "locality.locality", "pk": 289}, {"fields": {"true_model_id": null, "name": "Descanso", "short_name": null}, "model": "locality.locality", "pk": 290}, {"fields": {"true_model_id": null, "name": "Wilson", "short_name": null}, "model": "locality.locality", "pk": 291}, {"fields": {"true_model_id": null, "name": "Monument", "short_name": null}, "model": "locality.locality", "pk": 292}, {"fields": {"true_model_id": null, "name": "Capistrano Beach", "short_name": null}, "model": "locality.locality", "pk": 293}, {"fields": {"true_model_id": null, "name": "Houston", "short_name": null}, "model": "locality.locality", "pk": 294}, {"fields": {"true_model_id": null, "name": "San Rafael", "short_name": null}, "model": "locality.locality", "pk": 295}, {"fields": {"true_model_id": null, "name": "Placentia", "short_name": null}, "model": "locality.locality", "pk": 296}, {"fields": {"true_model_id": null, "name": "Redondo Beach", "short_name": null}, "model": "locality.locality", "pk": 297}, {"fields": {"true_model_id": null, "name": "Denver", "short_name": null}, "model": "locality.locality", "pk": 298}, {"fields": {"true_model_id": null, "name": "Richmond", "short_name": null}, "model": "locality.locality", "pk": 299}, {"fields": {"true_model_id": null, "name": "Canyon Lake", "short_name": null}, "model": "locality.locality", "pk": 300}, {"fields": {"true_model_id": null, "name": "Laguna Hills", "short_name": null}, "model": "locality.locality", "pk": 301}, {"fields": {"true_model_id": null, "name": "Bonsall", "short_name": null}, "model": "locality.locality", "pk": 302}, {"fields": {"true_model_id": null, "name": "Springfield", "short_name": null}, "model": "locality.locality", "pk": 303}, {"fields": {"true_model_id": null, "name": "Lake Forest", "short_name": null}, "model": "locality.locality", "pk": 304}, {"fields": {"true_model_id": null, "name": null, "short_name": "OK"}, "model": "locality.locality", "pk": 305}, {"fields": {"true_model_id": null, "name": "Oklahoma City", "short_name": null}, "model": "locality.locality", "pk": 306}, {"fields": {"true_model_id": null, "name": "Silver Spring", "short_name": null}, "model": "locality.locality", "pk": 307}, {"fields": {"true_model_id": null, "name": "Cedarhurst", "short_name": null}, "model": "locality.locality", "pk": 308}, {"fields": {"true_model_id": null, "name": "Encino", "short_name": null}, "model": "locality.locality", "pk": 309}, {"fields": {"true_model_id": null, "name": "Cambridge", "short_name": null}, "model": "locality.locality", "pk": 310}, {"fields": {"true_model_id": null, "name": "Cypress", "short_name": null}, "model": "locality.locality", "pk": 311}, {"fields": {"true_model_id": null, "name": "Bolingbrook", "short_name": null}, "model": "locality.locality", "pk": 312}, {"fields": {"true_model_id": null, "name": null, "short_name": "UK"}, "model": "locality.locality", "pk": 313}, {"fields": {"true_model_id": null, "name": "London", "short_name": null}, "model": "locality.locality", "pk": 314}, {"fields": {"true_model_id": null, "name": "Los Altos", "short_name": null}, "model": "locality.locality", "pk": 315}, {"fields": {"true_model_id": null, "name": "Quantico", "short_name": null}, "model": "locality.locality", "pk": 316}, {"fields": {"true_model_id": null, "name": "Spartanburg", "short_name": null}, "model": "locality.locality", "pk": 317}, {"fields": {"true_model_id": null, "name": "Crozet", "short_name": null}, "model": "locality.locality", "pk": 318}, {"fields": {"true_model_id": null, "name": null, "short_name": "OR"}, "model": "locality.locality", "pk": 319}, {"fields": {"true_model_id": null, "name": "Portland", "short_name": null}, "model": "locality.locality", "pk": 320}, {"fields": {"true_model_id": null, "name": "Pico Rivera", "short_name": null}, "model": "locality.locality", "pk": 321}, {"fields": {"true_model_id": null, "name": "Bloomington", "short_name": null}, "model": "locality.locality", "pk": 322}, {"fields": {"true_model_id": null, "name": "Pomona", "short_name": null}, "model": "locality.locality", "pk": 323}, {"fields": {"true_model_id": null, "name": "Hanover", "short_name": null}, "model": "locality.locality", "pk": 324}, {"fields": {"true_model_id": null, "name": "Aurora", "short_name": null}, "model": "locality.locality", "pk": 325}, {"fields": {"true_model_id": null, "name": "Philadelphia", "short_name": null}, "model": "locality.locality", "pk": 326}, {"fields": {"true_model_id": null, "name": "Santa Fe Springs", "short_name": null}, "model": "locality.locality", "pk": 327}, {"fields": {"true_model_id": null, "name": null, "short_name": "UT"}, "model": "locality.locality", "pk": 328}, {"fields": {"true_model_id": null, "name": "Park City", "short_name": null}, "model": "locality.locality", "pk": 329}, {"fields": {"true_model_id": null, "name": "Schaumburg", "short_name": null}, "model": "locality.locality", "pk": 330}, {"fields": {"true_model_id": null, "name": "Lake Forest", "short_name": null}, "model": "locality.locality", "pk": 331}, {"fields": {"true_model_id": null, "name": "Aliso Viejo", "short_name": null}, "model": "locality.locality", "pk": 332}, {"fields": {"true_model_id": null, "name": "Fountain Hills", "short_name": null}, "model": "locality.locality", "pk": 333}, {"fields": {"true_model_id": null, "name": "Blue Springs", "short_name": null}, "model": "locality.locality", "pk": 334}, {"fields": {"true_model_id": null, "name": "Benicia", "short_name": null}, "model": "locality.locality", "pk": 335}, {"fields": {"true_model_id": null, "name": "La Palma", "short_name": null}, "model": "locality.locality", "pk": 336}, {"fields": {"true_model_id": null, "name": "Redlands", "short_name": null}, "model": "locality.locality", "pk": 337}, {"fields": {"true_model_id": null, "name": "Waltham", "short_name": null}, "model": "locality.locality", "pk": 338}, {"fields": {"true_model_id": null, "name": "Valencia", "short_name": null}, "model": "locality.locality", "pk": 339}, {"fields": {"true_model_id": null, "name": "Sonoma", "short_name": null}, "model": "locality.locality", "pk": 340}, {"fields": {"true_model_id": null, "name": "Perris", "short_name": null}, "model": "locality.locality", "pk": 341}, {"fields": {"true_model_id": null, "name": "Jackson", "short_name": null}, "model": "locality.locality", "pk": 342}, {"fields": {"true_model_id": null, "name": null, "short_name": "WI"}, "model": "locality.locality", "pk": 343}, {"fields": {"true_model_id": null, "name": "Milwaukee", "short_name": null}, "model": "locality.locality", "pk": 344}, {"fields": {"true_model_id": null, "name": "Tarzana", "short_name": null}, "model": "locality.locality", "pk": 345}, {"fields": {"true_model_id": null, "name": "Danville", "short_name": null}, "model": "locality.locality", "pk": 346}, {"fields": {"true_model_id": null, "name": "Oracle", "short_name": null}, "model": "locality.locality", "pk": 347}, {"fields": {"true_model_id": null, "name": "Manhattan Beach", "short_name": null}, "model": "locality.locality", "pk": 348}, {"fields": {"true_model_id": null, "name": "Santa Monica", "short_name": null}, "model": "locality.locality", "pk": 349}, {"fields": {"true_model_id": null, "name": "San Carlos", "short_name": null}, "model": "locality.locality", "pk": 350}, {"fields": {"true_model_id": null, "name": "San Pedro", "short_name": null}, "model": "locality.locality", "pk": 351}, {"fields": {"true_model_id": null, "name": "Mill Valley", "short_name": null}, "model": "locality.locality", "pk": 352}, {"fields": {"true_model_id": null, "name": "Altadena", "short_name": null}, "model": "locality.locality", "pk": 353}, {"fields": {"true_model_id": null, "name": "Mira Loma", "short_name": null}, "model": "locality.locality", "pk": 354}, {"fields": {"true_model_id": null, "name": "Menifee", "short_name": null}, "model": "locality.locality", "pk": 355}, {"fields": {"true_model_id": null, "name": "Redding", "short_name": null}, "model": "locality.locality", "pk": 356}, {"fields": {"true_model_id": null, "name": "Costa Mesa", "short_name": null}, "model": "locality.locality", "pk": 357}, {"fields": {"true_model_id": null, "name": "Cardiff", "short_name": null}, "model": "locality.locality", "pk": 358}, {"fields": {"true_model_id": null, "name": null, "short_name": "AE"}, "model": "locality.locality", "pk": 359}, {"fields": {"true_model_id": null, "name": "France", "short_name": null}, "model": "locality.locality", "pk": 360}, {"fields": {"true_model_id": null, "name": "Napa", "short_name": null}, "model": "locality.locality", "pk": 361}, {"fields": {"true_model_id": null, "name": "Mission Viejo", "short_name": null}, "model": "locality.locality", "pk": 362}, {"fields": {"true_model_id": null, "name": "San Bernardino", "short_name": null}, "model": "locality.locality", "pk": 363}, {"fields": {"true_model_id": null, "name": null, "short_name": "KS"}, "model": "locality.locality", "pk": 364}, {"fields": {"true_model_id": null, "name": "Lenexa", "short_name": null}, "model": "locality.locality", "pk": 365}, {"fields": {"true_model_id": null, "name": "La Canada Flintridge", "short_name": null}, "model": "locality.locality", "pk": 366}, {"fields": {"true_model_id": null, "name": "Spokane", "short_name": null}, "model": "locality.locality", "pk": 367}, {"fields": {"true_model_id": null, "name": "Seal Beach", "short_name": null}, "model": "locality.locality", "pk": 368}, {"fields": {"true_model_id": null, "name": "Henderson", "short_name": null}, "model": "locality.locality", "pk": 369}, {"fields": {"true_model_id": null, "name": "Rancho Santa Margarita", "short_name": null}, "model": "locality.locality", "pk": 370}, {"fields": {"true_model_id": null, "name": "Leawood", "short_name": null}, "model": "locality.locality", "pk": 371}, {"fields": {"true_model_id": null, "name": "Millis", "short_name": null}, "model": "locality.locality", "pk": 372}, {"fields": {"true_model_id": null, "name": null, "short_name": "MS"}, "model": "locality.locality", "pk": 373}, {"fields": {"true_model_id": null, "name": "Biloxi", "short_name": null}, "model": "locality.locality", "pk": 374}, {"fields": {"true_model_id": null, "name": "Novato", "short_name": null}, "model": "locality.locality", "pk": 375}, {"fields": {"true_model_id": null, "name": "Ladera Ranch", "short_name": null}, "model": "locality.locality", "pk": 376}, {"fields": {"true_model_id": null, "name": "Bellflower", "short_name": null}, "model": "locality.locality", "pk": 377}, {"fields": {"true_model_id": null, "name": "Brighton", "short_name": null}, "model": "locality.locality", "pk": 378}, {"fields": {"true_model_id": null, "name": "Julian", "short_name": null}, "model": "locality.locality", "pk": 379}, {"fields": {"true_model_id": null, "name": "Thompson", "short_name": null}, "model": "locality.locality", "pk": 380}, {"fields": {"true_model_id": null, "name": null, "short_name": "NH"}, "model": "locality.locality", "pk": 381}, {"fields": {"true_model_id": null, "name": "Hopkinton", "short_name": null}, "model": "locality.locality", "pk": 382}, {"fields": {"true_model_id": null, "name": null, "short_name": "KY"}, "model": "locality.locality", "pk": 383}, {"fields": {"true_model_id": null, "name": "Lexington", "short_name": null}, "model": "locality.locality", "pk": 384}, {"fields": {"true_model_id": null, "name": "Granada Hills", "short_name": null}, "model": "locality.locality", "pk": 385}, {"fields": {"true_model_id": null, "name": "Sammamish", "short_name": null}, "model": "locality.locality", "pk": 386}, {"fields": {"true_model_id": null, "name": "La Verne", "short_name": null}, "model": "locality.locality", "pk": 387}, {"fields": {"true_model_id": null, "name": "Odenton", "short_name": null}, "model": "locality.locality", "pk": 388}, {"fields": {"true_model_id": null, "name": "Santa Paula", "short_name": null}, "model": "locality.locality", "pk": 389}, {"fields": {"true_model_id": null, "name": "North Bay Village", "short_name": null}, "model": "locality.locality", "pk": 390}, {"fields": {"true_model_id": null, "name": "Lakewood", "short_name": null}, "model": "locality.locality", "pk": 391}, {"fields": {"true_model_id": null, "name": null, "short_name": "ND"}, "model": "locality.locality", "pk": 392}, {"fields": {"true_model_id": null, "name": "Minot Afb", "short_name": null}, "model": "locality.locality", "pk": 393}, {"fields": {"true_model_id": null, "name": "Bend", "short_name": null}, "model": "locality.locality", "pk": 394}, {"fields": {"true_model_id": null, "name": "Abilene", "short_name": null}, "model": "locality.locality", "pk": 395}, {"fields": {"true_model_id": null, "name": "Mineral Wells", "short_name": null}, "model": "locality.locality", "pk": 396}, {"fields": {"true_model_id": null, "name": "Lo Jolla", "short_name": null}, "model": "locality.locality", "pk": 397}, {"fields": {"true_model_id": null, "name": "Lajolla", "short_name": null}, "model": "locality.locality", "pk": 398}, {"fields": {"true_model_id": null, "name": "Los Gatos", "short_name": null}, "model": "locality.locality", "pk": 399}, {"fields": {"true_model_id": null, "name": "Rancho Sante Fe", "short_name": null}, "model": "locality.locality", "pk": 400}, {"fields": {"true_model_id": null, "name": "Mc Lean", "short_name": null}, "model": "locality.locality", "pk": 401}, {"fields": {"true_model_id": null, "name": "Mammoth Lakes", "short_name": null}, "model": "locality.locality", "pk": 402}, {"fields": {"true_model_id": null, "name": "Thousand Oaks", "short_name": null}, "model": "locality.locality", "pk": 403}, {"fields": {"true_model_id": null, "name": "Edina", "short_name": null}, "model": "locality.locality", "pk": 404}, {"fields": {"true_model_id": null, "name": "Port St Lucie", "short_name": null}, "model": "locality.locality", "pk": 405}, {"fields": {"true_model_id": null, "name": "Morrison", "short_name": null}, "model": "locality.locality", "pk": 406}, {"fields": {"true_model_id": null, "name": "Moraga", "short_name": null}, "model": "locality.locality", "pk": 407}, {"fields": {"true_model_id": null, "name": null, "short_name": "VT"}, "model": "locality.locality", "pk": 408}, {"fields": {"true_model_id": null, "name": "Lyndon", "short_name": null}, "model": "locality.locality", "pk": 409}, {"fields": {"true_model_id": null, "name": "Old Lyme", "short_name": null}, "model": "locality.locality", "pk": 410}, {"fields": {"true_model_id": null, "name": "Corte Madera", "short_name": null}, "model": "locality.locality", "pk": 411}, {"fields": {"true_model_id": null, "name": "Carlsbad", "short_name": null}, "model": "locality.locality", "pk": 412}, {"fields": {"true_model_id": null, "name": "Los Ayeles", "short_name": null}, "model": "locality.locality", "pk": 413}, {"fields": {"true_model_id": null, "name": "Tucson", "short_name": null}, "model": "locality.locality", "pk": 414}, {"fields": {"true_model_id": null, "name": "Fitchburg", "short_name": null}, "model": "locality.locality", "pk": 415}, {"fields": {"true_model_id": null, "name": "Arroyo Grande", "short_name": null}, "model": "locality.locality", "pk": 416}, {"fields": {"true_model_id": null, "name": "Turlock", "short_name": null}, "model": "locality.locality", "pk": 417}, {"fields": {"true_model_id": null, "name": "Bakersfield", "short_name": null}, "model": "locality.locality", "pk": 418}, {"fields": {"true_model_id": null, "name": "Wasco", "short_name": null}, "model": "locality.locality", "pk": 419}, {"fields": {"true_model_id": null, "name": "Dixon", "short_name": null}, "model": "locality.locality", "pk": 420}, {"fields": {"true_model_id": null, "name": "Stockton", "short_name": null}, "model": "locality.locality", "pk": 421}, {"fields": {"true_model_id": null, "name": "Mariposa", "short_name": null}, "model": "locality.locality", "pk": 422}, {"fields": {"true_model_id": null, "name": "Shafter", "short_name": null}, "model": "locality.locality", "pk": 423}, {"fields": {"true_model_id": null, "name": "Inglewood", "short_name": null}, "model": "locality.locality", "pk": 424}, {"fields": {"true_model_id": null, "name": "Boulevard", "short_name": null}, "model": "locality.locality", "pk": 425}, {"fields": {"true_model_id": null, "name": "Mount Laguna", "short_name": null}, "model": "locality.locality", "pk": 426}, {"fields": {"true_model_id": null, "name": "Aguanga", "short_name": null}, "model": "locality.locality", "pk": 427}, {"fields": {"true_model_id": null, "name": null, "short_name": "BC"}, "model": "locality.locality", "pk": 428}, {"fields": {"true_model_id": null, "name": "Burnaby", "short_name": null}, "model": "locality.locality", "pk": 429}, {"fields": {"true_model_id": null, "name": "Pauma Valley", "short_name": null}, "model": "locality.locality", "pk": 430}, {"fields": {"true_model_id": null, "name": "Anza", "short_name": null}, "model": "locality.locality", "pk": 431}, {"fields": {"true_model_id": null, "name": null, "short_name": "DE"}, "model": "locality.locality", "pk": 432}, {"fields": {"true_model_id": null, "name": "Wilmington", "short_name": null}, "model": "locality.locality", "pk": 433}, {"fields": {"true_model_id": null, "name": "Pleasantville", "short_name": null}, "model": "locality.locality", "pk": 434}, {"fields": {"true_model_id": null, "name": "Jacksonville", "short_name": null}, "model": "locality.locality", "pk": 435}, {"fields": {"true_model_id": null, "name": null, "short_name": "NJ"}, "model": "locality.locality", "pk": 436}, {"fields": {"true_model_id": null, "name": "Egg Harbor Township", "short_name": null}, "model": "locality.locality", "pk": 437}, {"fields": {"true_model_id": null, "name": "Medford", "short_name": null}, "model": "locality.locality", "pk": 438}, {"fields": {"true_model_id": null, "name": "Chevy Chase", "short_name": null}, "model": "locality.locality", "pk": 439}, {"fields": {"true_model_id": null, "name": "Media", "short_name": null}, "model": "locality.locality", "pk": 440}, {"fields": {"true_model_id": null, "name": "Jonesville", "short_name": null}, "model": "locality.locality", "pk": 441}, {"fields": {"true_model_id": null, "name": "Voctorville", "short_name": null}, "model": "locality.locality", "pk": 442}, {"fields": {"true_model_id": null, "name": "Tuxedo Park", "short_name": null}, "model": "locality.locality", "pk": 443}, {"fields": {"true_model_id": null, "name": "Point Pleasant", "short_name": null}, "model": "locality.locality", "pk": 444}, {"fields": {"true_model_id": null, "name": "Winnemucca", "short_name": null}, "model": "locality.locality", "pk": 445}, {"fields": {"true_model_id": null, "name": "Victorville", "short_name": null}, "model": "locality.locality", "pk": 446}, {"fields": {"true_model_id": null, "name": "Naperville", "short_name": null}, "model": "locality.locality", "pk": 447}, {"fields": {"true_model_id": null, "name": "Minneapolis", "short_name": null}, "model": "locality.locality", "pk": 448}, {"fields": {"true_model_id": null, "name": "Simpsonville", "short_name": null}, "model": "locality.locality", "pk": 449}, {"fields": {"true_model_id": null, "name": "Idyllwild", "short_name": null}, "model": "locality.locality", "pk": 450}, {"fields": {"true_model_id": null, "name": "Playa Vista", "short_name": null}, "model": "locality.locality", "pk": 451}, {"fields": {"true_model_id": null, "name": "Compton", "short_name": null}, "model": "locality.locality", "pk": 452}, {"fields": {"true_model_id": null, "name": "Headlesburh", "short_name": null}, "model": "locality.locality", "pk": 453}, {"fields": {"true_model_id": null, "name": "Jmul", "short_name": null}, "model": "locality.locality", "pk": 454}, {"fields": {"true_model_id": null, "name": "San Fernando", "short_name": null}, "model": "locality.locality", "pk": 455}, {"fields": {"true_model_id": null, "name": "West Bloonfiels", "short_name": null}, "model": "locality.locality", "pk": 456}, {"fields": {"true_model_id": null, "name": "Miami", "short_name": null}, "model": "locality.locality", "pk": 457}, {"fields": {"true_model_id": null, "name": "Walla Walla", "short_name": null}, "model": "locality.locality", "pk": 458}, {"fields": {"true_model_id": null, "name": "Simi Valley", "short_name": null}, "model": "locality.locality", "pk": 459}, {"fields": {"true_model_id": null, "name": "Westlake Village", "short_name": null}, "model": "locality.locality", "pk": 460}, {"fields": {"true_model_id": null, "name": "Fresno", "short_name": null}, "model": "locality.locality", "pk": 461}, {"fields": {"true_model_id": null, "name": "Austin", "short_name": null}, "model": "locality.locality", "pk": 462}, {"fields": {"true_model_id": null, "name": "Ocean Beach", "short_name": null}, "model": "locality.locality", "pk": 463}, {"fields": {"true_model_id": null, "name": "Gladewater", "short_name": null}, "model": "locality.locality", "pk": 464}, {"fields": {"true_model_id": null, "name": "Doral", "short_name": null}, "model": "locality.locality", "pk": 465}, {"fields": {"true_model_id": null, "name": "Villa Park", "short_name": null}, "model": "locality.locality", "pk": 466}, {"fields": {"true_model_id": null, "name": "Blue Bell", "short_name": null}, "model": "locality.locality", "pk": 467}, {"fields": {"true_model_id": null, "name": "Mount Kisco", "short_name": null}, "model": "locality.locality", "pk": 468}, {"fields": {"true_model_id": null, "name": "Wilton", "short_name": null}, "model": "locality.locality", "pk": 469}, {"fields": {"true_model_id": null, "name": "Coeur D Alene", "short_name": null}, "model": "locality.locality", "pk": 470}, {"fields": {"true_model_id": null, "name": "West Linn", "short_name": null}, "model": "locality.locality", "pk": 471}, {"fields": {"true_model_id": null, "name": "Stevenson Ranch", "short_name": null}, "model": "locality.locality", "pk": 472}, {"fields": {"true_model_id": null, "name": "Chino Hills", "short_name": null}, "model": "locality.locality", "pk": 473}, {"fields": {"true_model_id": null, "name": "Waban", "short_name": null}, "model": "locality.locality", "pk": 474}, {"fields": {"true_model_id": null, "name": "Cave Creek", "short_name": null}, "model": "locality.locality", "pk": 475}, {"fields": {"true_model_id": null, "name": "San Luis Obispo", "short_name": null}, "model": "locality.locality", "pk": 476}, {"fields": {"true_model_id": null, "name": "Port Chester", "short_name": null}, "model": "locality.locality", "pk": 477}, {"fields": {"true_model_id": null, "name": "Palmetto Bay", "short_name": null}, "model": "locality.locality", "pk": 478}, {"fields": {"true_model_id": null, "name": "Tyler", "short_name": null}, "model": "locality.locality", "pk": 479}, {"fields": {"true_model_id": null, "name": "Glen Rock", "short_name": null}, "model": "locality.locality", "pk": 480}, {"fields": {"true_model_id": null, "name": "Dayton", "short_name": null}, "model": "locality.locality", "pk": 481}, {"fields": {"true_model_id": null, "name": "Georgetown", "short_name": null}, "model": "locality.locality", "pk": 482}, {"fields": {"true_model_id": null, "name": "Pacific Grove", "short_name": null}, "model": "locality.locality", "pk": 483}, {"fields": {"true_model_id": null, "name": "Chatsworth", "short_name": null}, "model": "locality.locality", "pk": 484}, {"fields": {"true_model_id": null, "name": "La Crescenta", "short_name": null}, "model": "locality.locality", "pk": 485}, {"fields": {"true_model_id": null, "name": "Fountain Valley", "short_name": null}, "model": "locality.locality", "pk": 486}, {"fields": {"true_model_id": null, "name": "Foothill Ranch", "short_name": null}, "model": "locality.locality", "pk": 487}, {"fields": {"true_model_id": null, "name": "Pahrump", "short_name": null}, "model": "locality.locality", "pk": 488}, {"fields": {"true_model_id": null, "name": "Santa Clarita", "short_name": null}, "model": "locality.locality", "pk": 489}, {"fields": {"true_model_id": null, "name": "Saint Helena", "short_name": null}, "model": "locality.locality", "pk": 490}, {"fields": {"true_model_id": null, "name": "St Joseph", "short_name": null}, "model": "locality.locality", "pk": 491}, {"fields": {"true_model_id": null, "name": "Antioch", "short_name": null}, "model": "locality.locality", "pk": 492}, {"fields": {"true_model_id": null, "name": "Piedmont", "short_name": null}, "model": "locality.locality", "pk": 493}, {"fields": {"true_model_id": null, "name": null, "short_name": "MT"}, "model": "locality.locality", "pk": 494}, {"fields": {"true_model_id": null, "name": "Bozeman", "short_name": null}, "model": "locality.locality", "pk": 495}, {"fields": {"true_model_id": null, "name": "Daly City", "short_name": null}, "model": "locality.locality", "pk": 496}, {"fields": {"true_model_id": null, "name": "Fairfield", "short_name": null}, "model": "locality.locality", "pk": 497}, {"fields": {"true_model_id": null, "name": "Pinole", "short_name": null}, "model": "locality.locality", "pk": 498}, {"fields": {"true_model_id": null, "name": "Castro Valley", "short_name": null}, "model": "locality.locality", "pk": 499}, {"fields": {"true_model_id": null, "name": "Fremont", "short_name": null}, "model": "locality.locality", "pk": 500}, {"fields": {"true_model_id": null, "name": "Point Richmond", "short_name": null}, "model": "locality.locality", "pk": 501}, {"fields": {"true_model_id": null, "name": "Hercules", "short_name": null}, "model": "locality.locality", "pk": 502}, {"fields": {"true_model_id": null, "name": "Emeryville", "short_name": null}, "model": "locality.locality", "pk": 503}, {"fields": {"true_model_id": null, "name": "Galt", "short_name": null}, "model": "locality.locality", "pk": 504}, {"fields": {"true_model_id": null, "name": "Davie", "short_name": null}, "model": "locality.locality", "pk": 505}, {"fields": {"true_model_id": null, "name": "West Hills", "short_name": null}, "model": "locality.locality", "pk": 506}, {"fields": {"true_model_id": null, "name": "Walnut Creek", "short_name": null}, "model": "locality.locality", "pk": 507}, {"fields": {"true_model_id": null, "name": "Santa Rosa", "short_name": null}, "model": "locality.locality", "pk": 508}, {"fields": {"true_model_id": null, "name": "El Sobrante", "short_name": null}, "model": "locality.locality", "pk": 509}, {"fields": {"true_model_id": null, "name": "Dublin", "short_name": null}, "model": "locality.locality", "pk": 510}, {"fields": {"true_model_id": null, "name": "Geneva", "short_name": null}, "model": "locality.locality", "pk": 511}, {"fields": {"true_model_id": null, "name": "Carmichael", "short_name": null}, "model": "locality.locality", "pk": 512}, {"fields": {"true_model_id": null, "name": "Clovis", "short_name": null}, "model": "locality.locality", "pk": 513}, {"fields": {"true_model_id": null, "name": "Woodland", "short_name": null}, "model": "locality.locality", "pk": 514}, {"fields": {"true_model_id": null, "name": "Rancho Cordova", "short_name": null}, "model": "locality.locality", "pk": 515}, {"fields": {"true_model_id": null, "name": "Beaumont", "short_name": null}, "model": "locality.locality", "pk": 516}, {"fields": {"true_model_id": null, "name": "Roseville", "short_name": null}, "model": "locality.locality", "pk": 517}, {"fields": {"true_model_id": null, "name": "Visalia", "short_name": null}, "model": "locality.locality", "pk": 518}, {"fields": {"true_model_id": null, "name": "Los Alamitos", "short_name": null}, "model": "locality.locality", "pk": 519}, {"fields": {"true_model_id": null, "name": "Sylmar", "short_name": null}, "model": "locality.locality", "pk": 520}, {"fields": {"true_model_id": null, "name": "Hilliard", "short_name": null}, "model": "locality.locality", "pk": 521}, {"fields": {"true_model_id": null, "name": "Auburn", "short_name": null}, "model": "locality.locality", "pk": 522}, {"fields": {"true_model_id": null, "name": "San Bruno", "short_name": null}, "model": "locality.locality", "pk": 523}, {"fields": {"true_model_id": null, "name": "Covina", "short_name": null}, "model": "locality.locality", "pk": 524}, {"fields": {"true_model_id": null, "name": "Fargo", "short_name": null}, "model": "locality.locality", "pk": 525}, {"fields": {"true_model_id": null, "name": "Waxhaw", "short_name": null}, "model": "locality.locality", "pk": 526}, {"fields": {"true_model_id": null, "name": "Hood River", "short_name": null}, "model": "locality.locality", "pk": 527}, {"fields": {"true_model_id": null, "name": "Union City", "short_name": null}, "model": "locality.locality", "pk": 528}, {"fields": {"true_model_id": null, "name": "Pleasant Hill", "short_name": null}, "model": "locality.locality", "pk": 529}, {"fields": {"true_model_id": null, "name": "Saint Paul", "short_name": null}, "model": "locality.locality", "pk": 530}, {"fields": {"true_model_id": null, "name": "Pacifica", "short_name": null}, "model": "locality.locality", "pk": 531}, {"fields": {"true_model_id": null, "name": "Sunnyvale", "short_name": null}, "model": "locality.locality", "pk": 532}, {"fields": {"true_model_id": null, "name": "Kensington", "short_name": null}, "model": "locality.locality", "pk": 533}, {"fields": {"true_model_id": null, "name": "Saratoga", "short_name": null}, "model": "locality.locality", "pk": 534}, {"fields": {"true_model_id": null, "name": "Santa Clara", "short_name": null}, "model": "locality.locality", "pk": 535}, {"fields": {"true_model_id": null, "name": "Pittsburg", "short_name": null}, "model": "locality.locality", "pk": 536}, {"fields": {"true_model_id": null, "name": "Norwalk", "short_name": null}, "model": "locality.locality", "pk": 537}, {"fields": {"true_model_id": null, "name": "Albany", "short_name": null}, "model": "locality.locality", "pk": 538}, {"fields": {"true_model_id": null, "name": "Hanover", "short_name": null}, "model": "locality.locality", "pk": 539}, {"fields": {"true_model_id": null, "name": "Villa Park", "short_name": null}, "model": "locality.locality", "pk": 540}, {"fields": {"true_model_id": null, "name": "Falls Church", "short_name": null}, "model": "locality.locality", "pk": 541}, {"fields": {"true_model_id": null, "name": "Albany", "short_name": null}, "model": "locality.locality", "pk": 542}, {"fields": {"true_model_id": null, "name": "Livermore", "short_name": null}, "model": "locality.locality", "pk": 543}, {"fields": {"true_model_id": null, "name": "Ferndale", "short_name": null}, "model": "locality.locality", "pk": 544}, {"fields": {"true_model_id": null, "name": "Sunol", "short_name": null}, "model": "locality.locality", "pk": 545}, {"fields": {"true_model_id": null, "name": "Daytona Beach", "short_name": null}, "model": "locality.locality", "pk": 546}, {"fields": {"true_model_id": null, "name": null, "short_name": "ME"}, "model": "locality.locality", "pk": 547}, {"fields": {"true_model_id": null, "name": "Portland", "short_name": null}, "model": "locality.locality", "pk": 548}, {"fields": {"true_model_id": null, "name": "Clayton", "short_name": null}, "model": "locality.locality", "pk": 549}, {"fields": {"true_model_id": null, "name": "Kelseyville", "short_name": null}, "model": "locality.locality", "pk": 550}, {"fields": {"true_model_id": null, "name": "Vallejo", "short_name": null}, "model": "locality.locality", "pk": 551}, {"fields": {"true_model_id": null, "name": "Geyserville", "short_name": null}, "model": "locality.locality", "pk": 552}, {"fields": {"true_model_id": null, "name": "Port Hueneme", "short_name": null}, "model": "locality.locality", "pk": 553}, {"fields": {"true_model_id": null, "name": "Potomac", "short_name": null}, "model": "locality.locality", "pk": 554}, {"fields": {"true_model_id": null, "name": "Hemet", "short_name": null}, "model": "locality.locality", "pk": 555}, {"fields": {"true_model_id": null, "name": "Chandler", "short_name": null}, "model": "locality.locality", "pk": 556}, {"fields": {"true_model_id": null, "name": "Tuckahoe", "short_name": null}, "model": "locality.locality", "pk": 557}, {"fields": {"true_model_id": null, "name": "Glencoe", "short_name": null}, "model": "locality.locality", "pk": 558}, {"fields": {"true_model_id": null, "name": "Bronxville", "short_name": null}, "model": "locality.locality", "pk": 559}, {"fields": {"true_model_id": null, "name": "Fairfield", "short_name": null}, "model": "locality.locality", "pk": 560}, {"fields": {"true_model_id": null, "name": "Nashville", "short_name": null}, "model": "locality.locality", "pk": 561}, {"fields": {"true_model_id": null, "name": "Concord", "short_name": null}, "model": "locality.locality", "pk": 562}, {"fields": {"true_model_id": null, "name": "Alexandria", "short_name": null}, "model": "locality.locality", "pk": 563}, {"fields": {"true_model_id": null, "name": "Chattanooga", "short_name": null}, "model": "locality.locality", "pk": 564}, {"fields": {"true_model_id": null, "name": "University Place", "short_name": null}, "model": "locality.locality", "pk": 565}, {"fields": {"true_model_id": null, "name": "Kentfield", "short_name": null}, "model": "locality.locality", "pk": 566}, {"fields": {"true_model_id": null, "name": "Bowie", "short_name": null}, "model": "locality.locality", "pk": 567}, {"fields": {"true_model_id": null, "name": "Modesto", "short_name": null}, "model": "locality.locality", "pk": 568}, {"fields": {"true_model_id": null, "name": "Rodeo", "short_name": null}, "model": "locality.locality", "pk": 569}, {"fields": {"true_model_id": null, "name": "St Louis", "short_name": null}, "model": "locality.locality", "pk": 570}, {"fields": {"true_model_id": null, "name": "Brentwood", "short_name": null}, "model": "locality.locality", "pk": 571}, {"fields": {"true_model_id": null, "name": "Diablo", "short_name": null}, "model": "locality.locality", "pk": 572}, {"fields": {"true_model_id": null, "name": "Milpitas", "short_name": null}, "model": "locality.locality", "pk": 573}, {"fields": {"true_model_id": null, "name": "Peeble Beach", "short_name": null}, "model": "locality.locality", "pk": 574}, {"fields": {"true_model_id": null, "name": "Merced", "short_name": null}, "model": "locality.locality", "pk": 575}, {"fields": {"true_model_id": null, "name": "Millbrae", "short_name": null}, "model": "locality.locality", "pk": 576}, {"fields": {"true_model_id": null, "name": "Petaluma", "short_name": null}, "model": "locality.locality", "pk": 577}, {"fields": {"true_model_id": null, "name": "Tracy", "short_name": null}, "model": "locality.locality", "pk": 578}, {"fields": {"true_model_id": null, "name": "Hamilton", "short_name": null}, "model": "locality.locality", "pk": 579}, {"fields": {"true_model_id": null, "name": "Villanova", "short_name": null}, "model": "locality.locality", "pk": 580}, {"fields": {"true_model_id": null, "name": "Portola Valley", "short_name": null}, "model": "locality.locality", "pk": 581}, {"fields": {"true_model_id": null, "name": "Palatine", "short_name": null}, "model": "locality.locality", "pk": 582}, {"fields": {"true_model_id": null, "name": "Jupiter", "short_name": null}, "model": "locality.locality", "pk": 583}, {"fields": {"true_model_id": null, "name": "Cherry Hill", "short_name": null}, "model": "locality.locality", "pk": 584}, {"fields": {"true_model_id": null, "name": "Los Altos Hills", "short_name": null}, "model": "locality.locality", "pk": 585}, {"fields": {"true_model_id": null, "name": "Boca Raton", "short_name": null}, "model": "locality.locality", "pk": 586}, {"fields": {"true_model_id": null, "name": "Montara", "short_name": null}, "model": "locality.locality", "pk": 587}, {"fields": {"true_model_id": null, "name": "Martinez", "short_name": null}, "model": "locality.locality", "pk": 588}, {"fields": {"true_model_id": null, "name": "Santa Cruz", "short_name": null}, "model": "locality.locality", "pk": 589}, {"fields": {"true_model_id": null, "name": "North Highlands", "short_name": null}, "model": "locality.locality", "pk": 590}, {"fields": {"true_model_id": null, "name": "Ross", "short_name": null}, "model": "locality.locality", "pk": 591}, {"fields": {"true_model_id": null, "name": "San Pablo", "short_name": null}, "model": "locality.locality", "pk": 592}, {"fields": {"true_model_id": null, "name": "Scranton", "short_name": null}, "model": "locality.locality", "pk": 593}, {"fields": {"true_model_id": null, "name": "Dacula", "short_name": null}, "model": "locality.locality", "pk": 594}, {"fields": {"true_model_id": null, "name": "Greenbrae", "short_name": null}, "model": "locality.locality", "pk": 595}, {"fields": {"true_model_id": null, "name": "Littleton", "short_name": null}, "model": "locality.locality", "pk": 596}, {"fields": {"true_model_id": null, "name": "Oviedo", "short_name": null}, "model": "locality.locality", "pk": 597}, {"fields": {"true_model_id": null, "name": "Half Moon Bay", "short_name": null}, "model": "locality.locality", "pk": 598}, {"fields": {"true_model_id": null, "name": "Ridgefield", "short_name": null}, "model": "locality.locality", "pk": 599}, {"fields": {"true_model_id": null, "name": "Pidemont", "short_name": null}, "model": "locality.locality", "pk": 600}, {"fields": {"true_model_id": null, "name": "Boulder Creek", "short_name": null}, "model": "locality.locality", "pk": 601}, {"fields": {"true_model_id": null, "name": "Nevada City", "short_name": null}, "model": "locality.locality", "pk": 602}, {"fields": {"true_model_id": null, "name": "Takoma Park", "short_name": null}, "model": "locality.locality", "pk": 603}, {"fields": {"true_model_id": null, "name": "Topanga", "short_name": null}, "model": "locality.locality", "pk": 604}, {"fields": {"true_model_id": null, "name": "Greenlaw", "short_name": null}, "model": "locality.locality", "pk": 605}, {"fields": {"true_model_id": null, "name": "Tigard", "short_name": null}, "model": "locality.locality", "pk": 606}, {"fields": {"true_model_id": null, "name": "Terre Linda", "short_name": null}, "model": "locality.locality", "pk": 607}, {"fields": {"true_model_id": null, "name": "Rosendale", "short_name": null}, "model": "locality.locality", "pk": 608}, {"fields": {"true_model_id": null, "name": "Baltimore", "short_name": null}, "model": "locality.locality", "pk": 609}, {"fields": {"true_model_id": null, "name": "Ithaca", "short_name": null}, "model": "locality.locality", "pk": 610}, {"fields": {"true_model_id": null, "name": "Nipomo", "short_name": null}, "model": "locality.locality", "pk": 611}, {"fields": {"true_model_id": null, "name": "San Diegeo", "short_name": null}, "model": "locality.locality", "pk": 612}, {"fields": {"true_model_id": null, "name": "Oyster Bay", "short_name": null}, "model": "locality.locality", "pk": 613}, {"fields": {"true_model_id": null, "name": "Richmon", "short_name": null}, "model": "locality.locality", "pk": 614}, {"fields": {"true_model_id": null, "name": "San Anselmo", "short_name": null}, "model": "locality.locality", "pk": 615}, {"fields": {"true_model_id": null, "name": "Ione", "short_name": null}, "model": "locality.locality", "pk": 616}, {"fields": {"true_model_id": null, "name": "Baton Rouge", "short_name": null}, "model": "locality.locality", "pk": 617}, {"fields": {"true_model_id": null, "name": "Victoria", "short_name": null}, "model": "locality.locality", "pk": 618}, {"fields": {"true_model_id": null, "name": "Larkspur", "short_name": null}, "model": "locality.locality", "pk": 619}, {"fields": {"true_model_id": null, "name": "Renfrew", "short_name": null}, "model": "locality.locality", "pk": 620}, {"fields": {"true_model_id": null, "name": "New Work", "short_name": null}, "model": "locality.locality", "pk": 621}, {"fields": {"true_model_id": null, "name": "Berwyn", "short_name": null}, "model": "locality.locality", "pk": 622}, {"fields": {"true_model_id": null, "name": "Pittsburgh", "short_name": null}, "model": "locality.locality", "pk": 623}, {"fields": {"true_model_id": null, "name": "Butler", "short_name": null}, "model": "locality.locality", "pk": 624}, {"fields": {"true_model_id": null, "name": "Detroit", "short_name": null}, "model": "locality.locality", "pk": 625}, {"fields": {"true_model_id": null, "name": "Bell Canyon", "short_name": null}, "model": "locality.locality", "pk": 626}, {"fields": {"true_model_id": null, "name": "Newton", "short_name": null}, "model": "locality.locality", "pk": 627}, {"fields": {"true_model_id": null, "name": "Easton", "short_name": null}, "model": "locality.locality", "pk": 628}, {"fields": {"true_model_id": null, "name": "College Station", "short_name": null}, "model": "locality.locality", "pk": 629}, {"fields": {"true_model_id": null, "name": "Walnut Creeek", "short_name": null}, "model": "locality.locality", "pk": 630}, {"fields": {"true_model_id": null, "name": "Carmel", "short_name": null}, "model": "locality.locality", "pk": 631}, {"fields": {"true_model_id": null, "name": "Aptos", "short_name": null}, "model": "locality.locality", "pk": 632}, {"fields": {"true_model_id": null, "name": "Fairfax", "short_name": null}, "model": "locality.locality", "pk": 633}, {"fields": {"true_model_id": null, "name": "La", "short_name": null}, "model": "locality.locality", "pk": 634}, {"fields": {"true_model_id": null, "name": "Lancaster", "short_name": null}, "model": "locality.locality", "pk": 635}, {"fields": {"true_model_id": null, "name": "Foster City", "short_name": null}, "model": "locality.locality", "pk": 636}, {"fields": {"true_model_id": null, "name": null, "short_name": "AL"}, "model": "locality.locality", "pk": 639}, {"fields": {"true_model_id": null, "name": "Santa Fe", "short_name": null}, "model": "locality.locality", "pk": 640}, {"fields": {"true_model_id": null, "name": "Malvern", "short_name": null}, "model": "locality.locality", "pk": 641}, {"fields": {"true_model_id": null, "name": "East Palo Alto", "short_name": null}, "model": "locality.locality", "pk": 642}, {"fields": {"true_model_id": null, "name": "Santa Fe", "short_name": null}, "model": "locality.locality", "pk": 643}, {"fields": {"true_model_id": null, "name": "Stanford", "short_name": null}, "model": "locality.locality", "pk": 644}, {"fields": {"true_model_id": null, "name": "Flint Hill", "short_name": null}, "model": "locality.locality", "pk": 645}, {"fields": {"true_model_id": null, "name": "Dunn Loring", "short_name": null}, "model": "locality.locality", "pk": 646}, {"fields": {"true_model_id": null, "name": "Campbell", "short_name": null}, "model": "locality.locality", "pk": 647}, {"fields": {"true_model_id": null, "name": "Somerville", "short_name": null}, "model": "locality.locality", "pk": 648}, {"fields": {"true_model_id": null, "name": "Haverford", "short_name": null}, "model": "locality.locality", "pk": 649}, {"fields": {"true_model_id": null, "name": "Arlington", "short_name": null}, "model": "locality.locality", "pk": 650}, {"fields": {"true_model_id": null, "name": "Hawthorne", "short_name": null}, "model": "locality.locality", "pk": 651}, {"fields": {"true_model_id": null, "name": "Pt. Richmond", "short_name": null}, "model": "locality.locality", "pk": 652}, {"fields": {"true_model_id": null, "name": "Zelienople", "short_name": null}, "model": "locality.locality", "pk": 653}, {"fields": {"true_model_id": null, "name": "Cumberland", "short_name": null}, "model": "locality.locality", "pk": 654}, {"fields": {"true_model_id": null, "name": "Superior", "short_name": null}, "model": "locality.locality", "pk": 655}, {"fields": {"true_model_id": null, "name": "Lamy", "short_name": null}, "model": "locality.locality", "pk": 656}, {"fields": {"true_model_id": null, "name": null, "short_name": "IA"}, "model": "locality.locality", "pk": 657}, {"fields": {"true_model_id": null, "name": "Leclaire", "short_name": null}, "model": "locality.locality", "pk": 658}, {"fields": {"true_model_id": null, "name": "Olympia", "short_name": null}, "model": "locality.locality", "pk": 659}, {"fields": {"true_model_id": null, "name": "Denton", "short_name": null}, "model": "locality.locality", "pk": 660}, {"fields": {"true_model_id": null, "name": "Garnet Valley", "short_name": null}, "model": "locality.locality", "pk": 661}, {"fields": {"true_model_id": null, "name": "Palm Beach Gardens", "short_name": null}, "model": "locality.locality", "pk": 662}, {"fields": {"true_model_id": null, "name": null, "short_name": "SD"}, "model": "locality.locality", "pk": 663}, {"fields": {"true_model_id": null, "name": "Sioux Falls", "short_name": null}, "model": "locality.locality", "pk": 664}, {"fields": {"true_model_id": null, "name": "Portsmouth", "short_name": null}, "model": "locality.locality", "pk": 665}, {"fields": {"true_model_id": null, "name": "Marina Del Ray", "short_name": null}, "model": "locality.locality", "pk": 666}, {"fields": {"true_model_id": null, "name": "Alexandria", "short_name": null}, "model": "locality.locality", "pk": 667}, {"fields": {"true_model_id": null, "name": "Cresskill", "short_name": null}, "model": "locality.locality", "pk": 668}, {"fields": {"true_model_id": null, "name": "Bonita Springs", "short_name": null}, "model": "locality.locality", "pk": 669}, {"fields": {"true_model_id": null, "name": "Rye", "short_name": null}, "model": "locality.locality", "pk": 670}, {"fields": {"true_model_id": null, "name": "Stevensville", "short_name": null}, "model": "locality.locality", "pk": 671}, {"fields": {"true_model_id": null, "name": "Armonk", "short_name": null}, "model": "locality.locality", "pk": 672}, {"fields": {"true_model_id": null, "name": "Grants Pass", "short_name": null}, "model": "locality.locality", "pk": 673}, {"fields": {"true_model_id": null, "name": "Burlingame", "short_name": null}, "model": "locality.locality", "pk": 674}, {"fields": {"true_model_id": null, "name": "Woodside", "short_name": null}, "model": "locality.locality", "pk": 675}, {"fields": {"true_model_id": null, "name": "Belvedere", "short_name": null}, "model": "locality.locality", "pk": 676}, {"fields": {"true_model_id": null, "name": "Nicasio", "short_name": null}, "model": "locality.locality", "pk": 677}, {"fields": {"true_model_id": null, "name": "Inverness", "short_name": null}, "model": "locality.locality", "pk": 678}, {"fields": {"true_model_id": null, "name": "Bottle Creek", "short_name": null}, "model": "locality.locality", "pk": 679}, {"fields": {"true_model_id": null, "name": "Midland", "short_name": null}, "model": "locality.locality", "pk": 680}, {"fields": {"true_model_id": null, "name": "Rockport", "short_name": null}, "model": "locality.locality", "pk": 681}, {"fields": {"true_model_id": null, "name": "Chino", "short_name": null}, "model": "locality.locality", "pk": 682}, {"fields": {"true_model_id": null, "name": "Columbus", "short_name": null}, "model": "locality.locality", "pk": 683}, {"fields": {"true_model_id": null, "name": "Woodland Hills", "short_name": null}, "model": "locality.locality", "pk": 684}, {"fields": {"true_model_id": null, "name": "Rossmoor", "short_name": null}, "model": "locality.locality", "pk": 685}, {"fields": {"true_model_id": null, "name": "Ocean Springs", "short_name": null}, "model": "locality.locality", "pk": 686}, {"fields": {"true_model_id": null, "name": "Cherry Hills Village", "short_name": null}, "model": "locality.locality", "pk": 687}, {"fields": {"true_model_id": null, "name": "Telluride", "short_name": null}, "model": "locality.locality", "pk": 688}, {"fields": {"true_model_id": null, "name": "Atherton", "short_name": null}, "model": "locality.locality", "pk": 689}, {"fields": {"true_model_id": null, "name": "Stevens Point", "short_name": null}, "model": "locality.locality", "pk": 690}, {"fields": {"true_model_id": null, "name": "Eastvale", "short_name": null}, "model": "locality.locality", "pk": 691}, {"fields": {"true_model_id": null, "name": "Prescott", "short_name": null}, "model": "locality.locality", "pk": 692}, {"fields": {"true_model_id": null, "name": "Delray Beach", "short_name": null}, "model": "locality.locality", "pk": 693}, {"fields": {"true_model_id": null, "name": "Borrego Springs", "short_name": null}, "model": "locality.locality", "pk": 694}, {"fields": {"true_model_id": null, "name": "Fort Worth", "short_name": null}, "model": "locality.locality", "pk": 695}, {"fields": {"true_model_id": null, "name": "Tulsa", "short_name": null}, "model": "locality.locality", "pk": 696}, {"fields": {"true_model_id": null, "name": "Parks", "short_name": null}, "model": "locality.locality", "pk": 697}, {"fields": {"true_model_id": null, "name": "Powder Springs", "short_name": null}, "model": "locality.locality", "pk": 698}, {"fields": {"true_model_id": null, "name": "Cheshire", "short_name": null}, "model": "locality.locality", "pk": 699}, {"fields": {"true_model_id": null, "name": "Ambler", "short_name": null}, "model": "locality.locality", "pk": 700}, {"fields": {"true_model_id": null, "name": "Veblen", "short_name": null}, "model": "locality.locality", "pk": 701}, {"fields": {"true_model_id": null, "name": "Canyon Country", "short_name": null}, "model": "locality.locality", "pk": 702}, {"fields": {"true_model_id": null, "name": "Mc Kinney", "short_name": null}, "model": "locality.locality", "pk": 703}, {"fields": {"true_model_id": null, "name": "Boulder City", "short_name": null}, "model": "locality.locality", "pk": 704}, {"fields": {"true_model_id": null, "name": "Newbury Park", "short_name": null}, "model": "locality.locality", "pk": 705}, {"fields": {"true_model_id": null, "name": null, "short_name": "AK"}, "model": "locality.locality", "pk": 706}, {"fields": {"true_model_id": null, "name": "Anchorage", "short_name": null}, "model": "locality.locality", "pk": 707}, {"fields": {"true_model_id": null, "name": "Walnut", "short_name": null}, "model": "locality.locality", "pk": 708}, {"fields": {"true_model_id": null, "name": "Leucadia", "short_name": null}, "model": "locality.locality", "pk": 709}, {"fields": {"true_model_id": null, "name": "San Dieo", "short_name": null}, "model": "locality.locality", "pk": 710}, {"fields": {"true_model_id": null, "name": "San Diego", "short_name": null}, "model": "locality.locality", "pk": 711}, {"fields": {"true_model_id": null, "name": "La Jolla", "short_name": null}, "model": "locality.locality", "pk": 712}, {"fields": {"true_model_id": null, "name": "Norwalk", "short_name": null}, "model": "locality.locality", "pk": 713}, {"fields": {"true_model_id": null, "name": "Montgomery", "short_name": null}, "model": "locality.locality", "pk": 714}, {"fields": {"true_model_id": null, "name": "Temple Terrace", "short_name": null}, "model": "locality.locality", "pk": 715}, {"fields": {"true_model_id": null, "name": "Missoula", "short_name": null}, "model": "locality.locality", "pk": 716}, {"fields": {"true_model_id": null, "name": "Windemere", "short_name": null}, "model": "locality.locality", "pk": 717}, {"fields": {"true_model_id": null, "name": "Arden", "short_name": null}, "model": "locality.locality", "pk": 718}, {"fields": {"true_model_id": null, "name": "Liverpool", "short_name": null}, "model": "locality.locality", "pk": 719}, {"fields": {"true_model_id": null, "name": "Sandpoint", "short_name": null}, "model": "locality.locality", "pk": 720}, {"fields": {"true_model_id": null, "name": "Stoughton", "short_name": null}, "model": "locality.locality", "pk": 721}, {"fields": {"true_model_id": null, "name": "Solona Beach", "short_name": null}, "model": "locality.locality", "pk": 722}, {"fields": {"true_model_id": null, "name": "Calexico", "short_name": null}, "model": "locality.locality", "pk": 723}, {"fields": {"true_model_id": null, "name": "Downers Grove", "short_name": null}, "model": "locality.locality", "pk": 724}, {"fields": {"true_model_id": null, "name": "Ventura", "short_name": null}, "model": "locality.locality", "pk": 725}, {"fields": {"true_model_id": null, "name": "Des Moines", "short_name": null}, "model": "locality.locality", "pk": 726}, {"fields": {"true_model_id": null, "name": "Signal Hill", "short_name": null}, "model": "locality.locality", "pk": 727}, {"fields": {"true_model_id": null, "name": "Newark", "short_name": null}, "model": "locality.locality", "pk": 728}, {"fields": {"true_model_id": null, "name": "Los Angelas", "short_name": null}, "model": "locality.locality", "pk": 729}, {"fields": {"true_model_id": null, "name": "Jurupa Valley", "short_name": null}, "model": "locality.locality", "pk": 730}, {"fields": {"true_model_id": null, "name": "West Palm Beach", "short_name": null}, "model": "locality.locality", "pk": 731}, {"fields": {"true_model_id": null, "name": "Ellicott City", "short_name": null}, "model": "locality.locality", "pk": 732}, {"fields": {"true_model_id": null, "name": "Oakhurst", "short_name": null}, "model": "locality.locality", "pk": 733}, {"fields": {"true_model_id": null, "name": "Carson", "short_name": null}, "model": "locality.locality", "pk": 734}, {"fields": {"true_model_id": null, "name": "Lodi", "short_name": null}, "model": "locality.locality", "pk": 735}, {"fields": {"true_model_id": null, "name": "Wenatchee", "short_name": null}, "model": "locality.locality", "pk": 736}, {"fields": {"true_model_id": null, "name": "Belleville", "short_name": null}, "model": "locality.locality", "pk": 737}, {"fields": {"true_model_id": null, "name": "Billerica", "short_name": null}, "model": "locality.locality", "pk": 738}, {"fields": {"true_model_id": null, "name": "Encinita", "short_name": null}, "model": "locality.locality", "pk": 739}, {"fields": {"true_model_id": null, "name": "North Falmouth", "short_name": null}, "model": "locality.locality", "pk": 740}, {"fields": {"true_model_id": null, "name": "Reston", "short_name": null}, "model": "locality.locality", "pk": 741}, {"fields": {"true_model_id": null, "name": "Bronx", "short_name": null}, "model": "locality.locality", "pk": 742}, {"fields": {"true_model_id": null, "name": "Palm Springs", "short_name": null}, "model": "locality.locality", "pk": 743}, {"fields": {"true_model_id": null, "name": "Deerfield", "short_name": null}, "model": "locality.locality", "pk": 744}, {"fields": {"true_model_id": null, "name": "Artesia", "short_name": null}, "model": "locality.locality", "pk": 745}, {"fields": {"true_model_id": null, "name": "Tuscumbia", "short_name": null}, "model": "locality.locality", "pk": 746}, {"fields": {"true_model_id": null, "name": "Douglaston", "short_name": null}, "model": "locality.locality", "pk": 747}, {"fields": {"true_model_id": null, "name": "Pearland", "short_name": null}, "model": "locality.locality", "pk": 748}, {"fields": {"true_model_id": null, "name": "Morrisville", "short_name": null}, "model": "locality.locality", "pk": 749}, {"fields": {"true_model_id": null, "name": "Redmond", "short_name": null}, "model": "locality.locality", "pk": 750}, {"fields": {"true_model_id": null, "name": "Agoura Hills", "short_name": null}, "model": "locality.locality", "pk": 751}, {"fields": {"true_model_id": null, "name": "Marlborough", "short_name": null}, "model": "locality.locality", "pk": 752}, {"fields": {"true_model_id": null, "name": "Yuma", "short_name": null}, "model": "locality.locality", "pk": 753}, {"fields": {"true_model_id": null, "name": "Crystal Bay", "short_name": null}, "model": "locality.locality", "pk": 754}, {"fields": {"true_model_id": null, "name": "Lorton", "short_name": null}, "model": "locality.locality", "pk": 755}, {"fields": {"true_model_id": null, "name": "Cary", "short_name": null}, "model": "locality.locality", "pk": 756}, {"fields": {"true_model_id": null, "name": "Rancho Mirage", "short_name": null}, "model": "locality.locality", "pk": 757}, {"fields": {"true_model_id": null, "name": "St Petersburg", "short_name": null}, "model": "locality.locality", "pk": 758}, {"fields": {"true_model_id": null, "name": "Granger", "short_name": null}, "model": "locality.locality", "pk": 759}, {"fields": {"true_model_id": null, "name": "Avon", "short_name": null}, "model": "locality.locality", "pk": 760}, {"fields": {"true_model_id": null, "name": "Eureka", "short_name": null}, "model": "locality.locality", "pk": 761}, {"fields": {"true_model_id": null, "name": "Flagstaff", "short_name": null}, "model": "locality.locality", "pk": 762}, {"fields": {"true_model_id": null, "name": "Caldwell", "short_name": null}, "model": "locality.locality", "pk": 763}, {"fields": {"true_model_id": null, "name": "Broomfield", "short_name": null}, "model": "locality.locality", "pk": 764}, {"fields": {"true_model_id": null, "name": "Stevensville", "short_name": null}, "model": "locality.locality", "pk": 765}, {"fields": {"true_model_id": null, "name": "El Toro", "short_name": null}, "model": "locality.locality", "pk": 766}, {"fields": {"true_model_id": null, "name": "Universal City", "short_name": null}, "model": "locality.locality", "pk": 767}, {"fields": {"true_model_id": null, "name": "Birmingham", "short_name": null}, "model": "locality.locality", "pk": 768}, {"fields": {"true_model_id": null, "name": "Granite Falls", "short_name": null}, "model": "locality.locality", "pk": 769}, {"fields": {"true_model_id": null, "name": "Porter Ranch", "short_name": null}, "model": "locality.locality", "pk": 770}, {"fields": {"true_model_id": null, "name": "Homewood", "short_name": null}, "model": "locality.locality", "pk": 771}, {"fields": {"true_model_id": null, "name": "South Orange", "short_name": null}, "model": "locality.locality", "pk": 772}, {"fields": {"true_model_id": null, "name": "Palos Verdes Estates", "short_name": null}, "model": "locality.locality", "pk": 773}, {"fields": {"true_model_id": null, "name": "Granite Bay", "short_name": null}, "model": "locality.locality", "pk": 774}, {"fields": {"true_model_id": null, "name": "Naples", "short_name": null}, "model": "locality.locality", "pk": 775}, {"fields": {"true_model_id": null, "name": "Satellite Beach", "short_name": null}, "model": "locality.locality", "pk": 776}, {"fields": {"true_model_id": null, "name": "Fayetteville", "short_name": null}, "model": "locality.locality", "pk": 777}, {"fields": {"true_model_id": null, "name": "Pompano Beach", "short_name": null}, "model": "locality.locality", "pk": 778}, {"fields": {"true_model_id": null, "name": "Elbum", "short_name": null}, "model": "locality.locality", "pk": 779}, {"fields": {"true_model_id": null, "name": "Helendale", "short_name": null}, "model": "locality.locality", "pk": 780}, {"fields": {"true_model_id": null, "name": "Ca", "short_name": null}, "model": "locality.locality", "pk": 781}, {"fields": {"true_model_id": null, "name": "Sugarland", "short_name": null}, "model": "locality.locality", "pk": 782}, {"fields": {"true_model_id": null, "name": "Salt Lake City", "short_name": null}, "model": "locality.locality", "pk": 783}, {"fields": {"true_model_id": null, "name": "Greeley", "short_name": null}, "model": "locality.locality", "pk": 784}, {"fields": {"true_model_id": null, "name": "Ranco Santa Fe", "short_name": null}, "model": "locality.locality", "pk": 785}, {"fields": {"true_model_id": null, "name": "Saint Louis", "short_name": null}, "model": "locality.locality", "pk": 786}, {"fields": {"true_model_id": null, "name": "Centennial", "short_name": null}, "model": "locality.locality", "pk": 787}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 395}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 751}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 427}, {"fields": {"county": null, "state": 172, "fips_id": null}, "model": "locality.city", "pk": 173}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 223}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 38}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 538}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 542}, {"fields": {"county": null, "state": 95, "fips_id": null}, "model": "locality.city", "pk": 96}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 563}, {"fields": {"county": null, "state": 383, "fips_id": null}, "model": "locality.city", "pk": 667}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 137}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 332}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 287}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 39}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 353}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 700}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 105}, {"fields": {"county": null, "state": 706, "fips_id": null}, "model": "locality.city", "pk": 707}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 152}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 492}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 431}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 632}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 266}, {"fields": {"county": null, "state": 53, "fips_id": null}, "model": "locality.city", "pk": 718}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 174}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 650}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 672}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 416}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 745}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 56}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 689}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 163}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 522}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 325}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 462}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 760}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 418}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 258}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 609}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 246}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 177}, {"fields": {"county": null, "state": 132, "fips_id": null}, "model": "locality.city", "pk": 617}, {"fields": {"county": null, "state": 142, "fips_id": null}, "model": "locality.city", "pk": 143}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 516}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 626}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 737}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 377}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 228}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 676}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 145}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 394}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 335}, {"fields": {"county": null, "state": 192, "fips_id": null}, "model": "locality.city", "pk": 193}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 124}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 622}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 42}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 75}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 101}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 738}, {"fields": {"county": null, "state": 373, "fips_id": null}, "model": "locality.city", "pk": 374}, {"fields": {"county": null, "state": 639, "fips_id": null}, "model": "locality.city", "pk": 768}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 322}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 467}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 334}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 586}, {"fields": {"county": null, "state": 99, "fips_id": null}, "model": "locality.city", "pk": 100}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 312}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 44}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 669}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 302}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 694}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 59}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 679}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 107}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 704}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 601}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 425}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 567}, {"fields": {"county": null, "state": 494, "fips_id": null}, "model": "locality.city", "pk": 495}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 7}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 571}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 378}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 742}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 559}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 220}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 237}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 764}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 151}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 203}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 674}, {"fields": {"county": null, "state": 428, "fips_id": null}, "model": "locality.city", "pk": 429}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 624}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 781}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 265}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 763}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 723}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 264}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 310}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 647}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 255}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 702}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 300}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 293}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 358}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 55}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 23}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 412}, {"fields": {"county": null, "state": 159, "fips_id": null}, "model": "locality.city", "pk": 160}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 631}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 512}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 734}, {"fields": {"county": null, "state": 53, "fips_id": null}, "model": "locality.city", "pk": 756}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 499}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 222}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 475}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 308}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 787}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 157}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 556}, {"fields": {"county": null, "state": 281, "fips_id": null}, "model": "locality.city", "pk": 282}, {"fields": {"county": null, "state": 53, "fips_id": null}, "model": "locality.city", "pk": 54}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 484}, {"fields": {"county": null, "state": 284, "fips_id": null}, "model": "locality.city", "pk": 564}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 584}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 687}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 90}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 699}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 439}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 19}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 682}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 473}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 72}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 251}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 199}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 549}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 513}, {"fields": {"county": null, "state": 85, "fips_id": null}, "model": "locality.city", "pk": 86}, {"fields": {"county": null, "state": 99, "fips_id": null}, "model": "locality.city", "pk": 470}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 629}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 40}, {"fields": {"county": null, "state": 273, "fips_id": null}, "model": "locality.city", "pk": 274}, {"fields": {"county": null, "state": 142, "fips_id": null}, "model": "locality.city", "pk": 683}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 452}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 562}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 155}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 262}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 32}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 411}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 357}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 277}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 65}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 524}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 668}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 318}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 754}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 257}, {"fields": {"county": null, "state": 547, "fips_id": null}, "model": "locality.city", "pk": 654}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 60}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 311}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 594}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 186}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 496}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 202}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 346}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 505}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 123}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 481}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 546}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 744}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 33}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 693}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 660}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 298}, {"fields": {"county": null, "state": 657, "fips_id": null}, "model": "locality.city", "pk": 726}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 290}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 625}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 572}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 70}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 420}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 465}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 747}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 198}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 724}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 80}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 510}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 646}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 642}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 628}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 691}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 269}, {"fields": {"county": null, "state": 273, "fips_id": null}, "model": "locality.city", "pk": 404}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 437}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 3}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 210}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 286}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 89}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 153}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 227}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 150}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 509}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 766}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 779}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 140}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 732}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 503}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 739}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 20}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 309}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 188}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 240}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 22}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 761}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 633}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 560}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 497}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 179}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 541}, {"fields": {"county": null, "state": 392, "fips_id": null}, "model": "locality.city", "pk": 525}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 777}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 544}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 415}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 762}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 645}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 487}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 215}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 695}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 636}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 333}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 486}, {"fields": {"county": null, "state": 359, "fips_id": null}, "model": "locality.city", "pk": 360}, {"fields": {"county": null, "state": 284, "fips_id": null}, "model": "locality.city", "pk": 285}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 500}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 461}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 141}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 504}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 272}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 661}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 511}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 482}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 552}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 464}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 480}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 558}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 92}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 131}, {"fields": {"county": null, "state": 159, "fips_id": null}, "model": "locality.city", "pk": 218}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 385}, {"fields": {"county": null, "state": 159, "fips_id": null}, "model": "locality.city", "pk": 759}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 774}, {"fields": {"county": null, "state": 53, "fips_id": null}, "model": "locality.city", "pk": 769}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 673}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 243}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 784}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 595}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 605}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 11}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 235}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 598}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 579}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 324}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 539}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 118}, {"fields": {"county": null, "state": 190, "fips_id": null}, "model": "locality.city", "pk": 191}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 649}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 651}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 139}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 453}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 780}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 555}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 369}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 502}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 126}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 180}, {"fields": {"county": null, "state": 142, "fips_id": null}, "model": "locality.city", "pk": 521}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 267}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 209}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 217}, {"fields": {"county": null, "state": 639, "fips_id": null}, "model": "locality.city", "pk": 771}, {"fields": {"county": null, "state": 172, "fips_id": null}, "model": "locality.city", "pk": 250}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 527}, {"fields": {"county": null, "state": 381, "fips_id": null}, "model": "locality.city", "pk": 382}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 294}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 47}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 450}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 109}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 279}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 97}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 424}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 678}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 616}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 45}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 189}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 610}, {"fields": {"county": null, "state": 85, "fips_id": null}, "model": "locality.city", "pk": 342}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 435}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 29}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 454}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 62}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 441}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 379}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 583}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 730}, {"fields": {"county": null, "state": 172, "fips_id": null}, "model": "locality.city", "pk": 270}, {"fields": {"county": null, "state": 172, "fips_id": null}, "model": "locality.city", "pk": 289}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 236}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 550}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 533}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 566}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 260}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 185}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 634}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 366}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 485}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 114}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 6}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 712}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 17}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 115}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 336}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 256}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 387}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 376}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 57}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 135}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 148}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 301}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 83}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 398}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 304}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 331}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 46}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 391}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 144}, {"fields": {"county": null, "state": 95, "fips_id": null}, "model": "locality.city", "pk": 656}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 635}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 619}, {"fields": {"county": null, "state": 95, "fips_id": null}, "model": "locality.city", "pk": 112}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 201}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 74}, {"fields": {"county": null, "state": 364, "fips_id": null}, "model": "locality.city", "pk": 371}, {"fields": {"county": null, "state": 657, "fips_id": null}, "model": "locality.city", "pk": 658}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 16}, {"fields": {"county": null, "state": 364, "fips_id": null}, "model": "locality.city", "pk": 365}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 709}, {"fields": {"county": null, "state": 383, "fips_id": null}, "model": "locality.city", "pk": 384}, {"fields": {"county": null, "state": 192, "fips_id": null}, "model": "locality.city", "pk": 248}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 596}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 543}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 719}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 397}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 735}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 161}, {"fields": {"county": null, "state": 313, "fips_id": null}, "model": "locality.city", "pk": 314}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 156}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 755}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 519}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 315}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 585}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 729}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 15}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 413}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 399}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 230}, {"fields": {"county": null, "state": 408, "fips_id": null}, "model": "locality.city", "pk": 409}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 288}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 641}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 402}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 348}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 263}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 666}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 50}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 422}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 752}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 588}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 13}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 703}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 401}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 438}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 440}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 355}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 147}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 575}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 226}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 88}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 457}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 130}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 680}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 352}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 576}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 372}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 573}, {"fields": {"county": null, "state": 343, "fips_id": null}, "model": "locality.city", "pk": 344}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 396}, {"fields": {"county": null, "state": 273, "fips_id": null}, "model": "locality.city", "pk": 448}, {"fields": {"county": null, "state": 392, "fips_id": null}, "model": "locality.city", "pk": 393}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 354}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 362}, {"fields": {"county": null, "state": 494, "fips_id": null}, "model": "locality.city", "pk": 716}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 568}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 587}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 127}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 714}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 292}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 407}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 406}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 749}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 468}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 426}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 91}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 146}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 43}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 361}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 447}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 775}, {"fields": {"county": null, "state": 284, "fips_id": null}, "model": "locality.city", "pk": 561}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 104}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 602}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 232}, {"fields": {"county": null, "state": 132, "fips_id": null}, "model": "locality.city", "pk": 133}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 621}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 77}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 728}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 705}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 175}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 49}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 110}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 229}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 627}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 677}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 611}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 166}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 390}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 740}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 590}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 252}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 154}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 713}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 537}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 375}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 733}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 117}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 463}, {"fields": {"county": null, "state": 373, "fips_id": null}, "model": "locality.city", "pk": 686}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 71}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 388}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 271}, {"fields": {"county": null, "state": 305, "fips_id": null}, "model": "locality.city", "pk": 306}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 410}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 659}, {"fields": {"county": null, "state": 181, "fips_id": null}, "model": "locality.city", "pk": 182}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 194}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 347}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 27}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 283}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 184}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 597}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 106}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 613}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 234}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 483}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 238}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 531}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 488}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 582}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 662}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 214}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 743}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 478}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 200}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 195}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 773}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 113}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 119}, {"fields": {"county": null, "state": 328, "fips_id": null}, "model": "locality.city", "pk": 329}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 697}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 78}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 430}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 748}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 574}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 341}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 577}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 326}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 5}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 321}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 600}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 493}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 498}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 536}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 623}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 296}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 276}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 451}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 529}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 241}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 434}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 444}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 501}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 323}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 778}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 477}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 553}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 128}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 405}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 770}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 320}, {"fields": {"county": null, "state": 547, "fips_id": null}, "model": "locality.city", "pk": 548}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 581}, {"fields": {"county": null, "state": 381, "fips_id": null}, "model": "locality.city", "pk": 665}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 554}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 26}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 698}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 692}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 652}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 316}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 64}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 515}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 278}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 757}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 24}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 370}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 400}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 785}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 253}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 356}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 337}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 750}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 297}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 125}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 620}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 221}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 741}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 614}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 299}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 167}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 599}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 25}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 136}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 681}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 138}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 569}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 608}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 517}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 591}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 685}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 165}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 254}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 670}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 233}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 14}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 490}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 786}, {"fields": {"county": null, "state": 273, "fips_id": null}, "model": "locality.city", "pk": 530}, {"fields": {"county": null, "state": 328, "fips_id": null}, "model": "locality.city", "pk": 783}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 386}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 615}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 212}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 363}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 523}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 350}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 93}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 612}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 711}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 2}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 710}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 455}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 9}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 178}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 225}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 196}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 204}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 476}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 34}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 247}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 120}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 592}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 351}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 295}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 21}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 239}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 207}, {"fields": {"county": null, "state": 99, "fips_id": null}, "model": "locality.city", "pk": 720}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 134}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 224}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 535}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 489}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 589}, {"fields": {"county": null, "state": 639, "fips_id": null}, "model": "locality.city", "pk": 640}, {"fields": {"county": null, "state": 95, "fips_id": null}, "model": "locality.city", "pk": 643}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 327}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 108}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 349}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 389}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 508}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 81}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 534}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 776}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 249}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 330}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 211}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 593}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 368}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 168}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 423}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 205}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 727}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 307}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 459}, {"fields": {"county": null, "state": 190, "fips_id": null}, "model": "locality.city", "pk": 449}, {"fields": {"county": null, "state": 169, "fips_id": null}, "model": "locality.city", "pk": 170}, {"fields": {"county": null, "state": 663, "fips_id": null}, "model": "locality.city", "pk": 664}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 216}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 8}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 171}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 722}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 648}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 340}, {"fields": {"county": null, "state": 436, "fips_id": null}, "model": "locality.city", "pk": 772}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 98}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 37}, {"fields": {"county": null, "state": 190, "fips_id": null}, "model": "locality.city", "pk": 317}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 367}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 35}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 303}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 491}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 570}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 758}, {"fields": {"county": null, "state": 66, "fips_id": null}, "model": "locality.city", "pk": 67}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 116}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 644}, {"fields": {"county": null, "state": 343, "fips_id": null}, "model": "locality.city", "pk": 690}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 472}, {"fields": {"county": null, "state": 494, "fips_id": null}, "model": "locality.city", "pk": 765}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 671}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 421}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 721}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 129}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 782}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 532}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 545}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 655}, {"fields": {"county": null, "state": 162, "fips_id": null}, "model": "locality.city", "pk": 268}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 520}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 103}, {"fields": {"county": null, "state": 41, "fips_id": null}, "model": "locality.city", "pk": 603}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 121}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 345}, {"fields": {"county": null, "state": 10, "fips_id": null}, "model": "locality.city", "pk": 688}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 28}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 259}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 715}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 607}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 380}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 403}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 261}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 606}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 604}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 187}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 164}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 280}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 578}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 557}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 414}, {"fields": {"county": null, "state": 305, "fips_id": null}, "model": "locality.city", "pk": 696}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 417}, {"fields": {"county": null, "state": 639, "fips_id": null}, "model": "locality.city", "pk": 746}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 84}, {"fields": {"county": null, "state": 76, "fips_id": null}, "model": "locality.city", "pk": 443}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 479}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 528}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 767}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 565}, {"fields": {"county": null, "state": 30, "fips_id": null}, "model": "locality.city", "pk": 31}, {"fields": {"county": null, "state": 244, "fips_id": null}, "model": "locality.city", "pk": 245}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 158}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 339}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 551}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 63}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 219}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 213}, {"fields": {"county": null, "state": 663, "fips_id": null}, "model": "locality.city", "pk": 701}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 242}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 725}, {"fields": {"county": null, "state": 79, "fips_id": null}, "model": "locality.city", "pk": 618}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 446}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 111}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 466}, {"fields": {"county": null, "state": 18, "fips_id": null}, "model": "locality.city", "pk": 540}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 580}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 94}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 518}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 36}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 442}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 474}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 458}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 708}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 630}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 507}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 338}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 419}, {"fields": {"county": null, "state": 51, "fips_id": null}, "model": "locality.city", "pk": 52}, {"fields": {"county": null, "state": 53, "fips_id": null}, "model": "locality.city", "pk": 526}, {"fields": {"county": null, "state": 102, "fips_id": null}, "model": "locality.city", "pk": 736}, {"fields": {"county": null, "state": 12, "fips_id": null}, "model": "locality.city", "pk": 456}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 506}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 208}, {"fields": {"county": null, "state": 319, "fips_id": null}, "model": "locality.city", "pk": 471}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 731}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 149}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 460}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 122}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 48}, {"fields": {"county": null, "state": 68, "fips_id": null}, "model": "locality.city", "pk": 69}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 206}, {"fields": {"county": null, "state": 432, "fips_id": null}, "model": "locality.city", "pk": 433}, {"fields": {"county": null, "state": 85, "fips_id": null}, "model": "locality.city", "pk": 291}, {"fields": {"county": null, "state": 231, "fips_id": null}, "model": "locality.city", "pk": 469}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 197}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 717}, {"fields": {"county": null, "state": 73, "fips_id": null}, "model": "locality.city", "pk": 445}, {"fields": {"county": null, "state": 87, "fips_id": null}, "model": "locality.city", "pk": 183}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 514}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 684}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 675}, {"fields": {"county": null, "state": 58, "fips_id": null}, "model": "locality.city", "pk": 275}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 82}, {"fields": {"county": null, "state": 1, "fips_id": null}, "model": "locality.city", "pk": 176}, {"fields": {"county": null, "state": 4, "fips_id": null}, "model": "locality.city", "pk": 753}, {"fields": {"county": null, "state": 61, "fips_id": null}, "model": "locality.city", "pk": 653}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 359}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 706}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 639}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 192}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 4}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 428}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 10}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 231}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 51}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 432}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 87}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 162}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 172}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 657}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 99}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 18}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 159}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 364}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 383}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 132}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 58}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 41}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 547}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 12}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 273}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 66}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 373}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 494}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 53}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 392}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 181}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 381}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 436}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 95}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 73}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 76}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 142}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 305}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 319}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 61}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 190}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 663}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 284}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 79}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 313}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 30}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 328}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 68}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 408}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 102}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 343}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 281}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 85}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 169}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 244}, {"fields": {"fips_id": null}, "model": "locality.state", "pk": 1}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92101"}, "model": "locality.zipcode", "pk": 1}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92121"}, "model": "locality.zipcode", "pk": 2}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92019"}, "model": "locality.zipcode", "pk": 3}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85054"}, "model": "locality.zipcode", "pk": 4}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92037"}, "model": "locality.zipcode", "pk": 5}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92103"}, "model": "locality.zipcode", "pk": 6}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92109"}, "model": "locality.zipcode", "pk": 7}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92123"}, "model": "locality.zipcode", "pk": 8}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92821"}, "model": "locality.zipcode", "pk": 9}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92119"}, "model": "locality.zipcode", "pk": 10}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92075"}, "model": "locality.zipcode", "pk": 11}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94105"}, "model": "locality.zipcode", "pk": 12}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92104"}, "model": "locality.zipcode", "pk": 13}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80111"}, "model": "locality.zipcode", "pk": 14}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92128"}, "model": "locality.zipcode", "pk": 15}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92111"}, "model": "locality.zipcode", "pk": 16}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92116"}, "model": "locality.zipcode", "pk": 17}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "48854"}, "model": "locality.zipcode", "pk": 18}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92110"}, "model": "locality.zipcode", "pk": 19}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92113"}, "model": "locality.zipcode", "pk": 20}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95814"}, "model": "locality.zipcode", "pk": 21}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92102"}, "model": "locality.zipcode", "pk": 22}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90020"}, "model": "locality.zipcode", "pk": 23}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91945"}, "model": "locality.zipcode", "pk": 24}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91942"}, "model": "locality.zipcode", "pk": 25}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92127"}, "model": "locality.zipcode", "pk": 26}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60611"}, "model": "locality.zipcode", "pk": 27}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92154"}, "model": "locality.zipcode", "pk": 28}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92024"}, "model": "locality.zipcode", "pk": 29}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94104"}, "model": "locality.zipcode", "pk": 30}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92106"}, "model": "locality.zipcode", "pk": 31}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92130"}, "model": "locality.zipcode", "pk": 32}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94583"}, "model": "locality.zipcode", "pk": 33}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92026"}, "model": "locality.zipcode", "pk": 34}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92139"}, "model": "locality.zipcode", "pk": 35}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92009"}, "model": "locality.zipcode", "pk": 36}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92067"}, "model": "locality.zipcode", "pk": 37}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92029"}, "model": "locality.zipcode", "pk": 38}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92008"}, "model": "locality.zipcode", "pk": 39}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92020"}, "model": "locality.zipcode", "pk": 40}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92108"}, "model": "locality.zipcode", "pk": 41}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92122"}, "model": "locality.zipcode", "pk": 42}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92501"}, "model": "locality.zipcode", "pk": 43}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92064"}, "model": "locality.zipcode", "pk": 44}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92025"}, "model": "locality.zipcode", "pk": 45}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92129"}, "model": "locality.zipcode", "pk": 46}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92131"}, "model": "locality.zipcode", "pk": 47}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91941"}, "model": "locality.zipcode", "pk": 48}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92869"}, "model": "locality.zipcode", "pk": 49}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92591"}, "model": "locality.zipcode", "pk": 50}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92114"}, "model": "locality.zipcode", "pk": 51}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92115"}, "model": "locality.zipcode", "pk": 52}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92107"}, "model": "locality.zipcode", "pk": 53}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91935"}, "model": "locality.zipcode", "pk": 54}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "00000"}, "model": "locality.zipcode", "pk": 55}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92118"}, "model": "locality.zipcode", "pk": 56}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92117"}, "model": "locality.zipcode", "pk": 57}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92124"}, "model": "locality.zipcode", "pk": 58}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92021"}, "model": "locality.zipcode", "pk": 59}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92014"}, "model": "locality.zipcode", "pk": 60}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92120"}, "model": "locality.zipcode", "pk": 61}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92069"}, "model": "locality.zipcode", "pk": 62}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91977"}, "model": "locality.zipcode", "pk": 63}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92126"}, "model": "locality.zipcode", "pk": 64}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92084"}, "model": "locality.zipcode", "pk": 65}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92011"}, "model": "locality.zipcode", "pk": 66}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94080"}, "model": "locality.zipcode", "pk": 67}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94507"}, "model": "locality.zipcode", "pk": 68}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91901"}, "model": "locality.zipcode", "pk": 69}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80907"}, "model": "locality.zipcode", "pk": 70}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20816"}, "model": "locality.zipcode", "pk": 71}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92562"}, "model": "locality.zipcode", "pk": 72}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92091"}, "model": "locality.zipcode", "pk": 73}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95821"}, "model": "locality.zipcode", "pk": 74}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91902"}, "model": "locality.zipcode", "pk": 75}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92603"}, "model": "locality.zipcode", "pk": 76}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92040"}, "model": "locality.zipcode", "pk": 77}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92614"}, "model": "locality.zipcode", "pk": 78}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92648"}, "model": "locality.zipcode", "pk": 79}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92595"}, "model": "locality.zipcode", "pk": 80}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92661"}, "model": "locality.zipcode", "pk": 81}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92081"}, "model": "locality.zipcode", "pk": 82}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94111"}, "model": "locality.zipcode", "pk": 83}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90292"}, "model": "locality.zipcode", "pk": 84}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92663"}, "model": "locality.zipcode", "pk": 85}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92078"}, "model": "locality.zipcode", "pk": 86}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20005"}, "model": "locality.zipcode", "pk": 87}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "28277"}, "model": "locality.zipcode", "pk": 88}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92007"}, "model": "locality.zipcode", "pk": 89}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "81611"}, "model": "locality.zipcode", "pk": 90}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92105"}, "model": "locality.zipcode", "pk": 91}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92694"}, "model": "locality.zipcode", "pk": 92}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02108"}, "model": "locality.zipcode", "pk": 93}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95014"}, "model": "locality.zipcode", "pk": 94}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "15909"}, "model": "locality.zipcode", "pk": 95}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92082"}, "model": "locality.zipcode", "pk": 96}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92065"}, "model": "locality.zipcode", "pk": 97}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91978"}, "model": "locality.zipcode", "pk": 98}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "96022"}, "model": "locality.zipcode", "pk": 99}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "63105"}, "model": "locality.zipcode", "pk": 100}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23185"}, "model": "locality.zipcode", "pk": 101}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91765"}, "model": "locality.zipcode", "pk": 102}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92058"}, "model": "locality.zipcode", "pk": 103}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91910"}, "model": "locality.zipcode", "pk": 104}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91913"}, "model": "locality.zipcode", "pk": 105}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89117"}, "model": "locality.zipcode", "pk": 106}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92057"}, "model": "locality.zipcode", "pk": 107}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90210"}, "model": "locality.zipcode", "pk": 108}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92054"}, "model": "locality.zipcode", "pk": 109}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10019"}, "model": "locality.zipcode", "pk": 110}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91914"}, "model": "locality.zipcode", "pk": 111}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91911"}, "model": "locality.zipcode", "pk": 112}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91104"}, "model": "locality.zipcode", "pk": 113}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91915"}, "model": "locality.zipcode", "pk": 114}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78619"}, "model": "locality.zipcode", "pk": 115}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92071"}, "model": "locality.zipcode", "pk": 116}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92886"}, "model": "locality.zipcode", "pk": 117}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92677"}, "model": "locality.zipcode", "pk": 118}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92010"}, "model": "locality.zipcode", "pk": 119}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92780"}, "model": "locality.zipcode", "pk": 120}, {"fields": {"county": null, "city": null, "state": 85, "name": null, "short_name": "82414"}, "model": "locality.zipcode", "pk": 121}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32952"}, "model": "locality.zipcode", "pk": 122}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92056"}, "model": "locality.zipcode", "pk": 123}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95864"}, "model": "locality.zipcode", "pk": 124}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95762"}, "model": "locality.zipcode", "pk": 125}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23323"}, "model": "locality.zipcode", "pk": 126}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92561"}, "model": "locality.zipcode", "pk": 127}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91203"}, "model": "locality.zipcode", "pk": 128}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95831"}, "model": "locality.zipcode", "pk": 129}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92673"}, "model": "locality.zipcode", "pk": 130}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92660"}, "model": "locality.zipcode", "pk": 131}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23457"}, "model": "locality.zipcode", "pk": 132}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87123"}, "model": "locality.zipcode", "pk": 133}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92201"}, "model": "locality.zipcode", "pk": 134}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91030"}, "model": "locality.zipcode", "pk": 135}, {"fields": {"county": null, "city": null, "state": 99, "name": null, "short_name": "83714"}, "model": "locality.zipcode", "pk": 136}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92315"}, "model": "locality.zipcode", "pk": 137}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92027"}, "model": "locality.zipcode", "pk": 138}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98407"}, "model": "locality.zipcode", "pk": 139}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91950"}, "model": "locality.zipcode", "pk": 140}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92807"}, "model": "locality.zipcode", "pk": 141}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90025"}, "model": "locality.zipcode", "pk": 142}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93030"}, "model": "locality.zipcode", "pk": 143}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80304"}, "model": "locality.zipcode", "pk": 144}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92093"}, "model": "locality.zipcode", "pk": 145}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93454"}, "model": "locality.zipcode", "pk": 146}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91932"}, "model": "locality.zipcode", "pk": 147}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92657"}, "model": "locality.zipcode", "pk": 148}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23322"}, "model": "locality.zipcode", "pk": 149}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20007"}, "model": "locality.zipcode", "pk": 150}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90064"}, "model": "locality.zipcode", "pk": 151}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60614"}, "model": "locality.zipcode", "pk": 152}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90211"}, "model": "locality.zipcode", "pk": 153}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91103"}, "model": "locality.zipcode", "pk": 154}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22180"}, "model": "locality.zipcode", "pk": 155}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20003"}, "model": "locality.zipcode", "pk": 156}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "88011"}, "model": "locality.zipcode", "pk": 157}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94114"}, "model": "locality.zipcode", "pk": 158}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95819"}, "model": "locality.zipcode", "pk": 159}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85013"}, "model": "locality.zipcode", "pk": 160}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85253"}, "model": "locality.zipcode", "pk": 161}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90061"}, "model": "locality.zipcode", "pk": 162}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95833"}, "model": "locality.zipcode", "pk": 163}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94117"}, "model": "locality.zipcode", "pk": 164}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90631"}, "model": "locality.zipcode", "pk": 165}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94107"}, "model": "locality.zipcode", "pk": 166}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90638"}, "model": "locality.zipcode", "pk": 167}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92801"}, "model": "locality.zipcode", "pk": 168}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22554"}, "model": "locality.zipcode", "pk": 169}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90041"}, "model": "locality.zipcode", "pk": 170}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94618"}, "model": "locality.zipcode", "pk": 171}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "17109"}, "model": "locality.zipcode", "pk": 172}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95835"}, "model": "locality.zipcode", "pk": 173}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91105"}, "model": "locality.zipcode", "pk": 174}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90048"}, "model": "locality.zipcode", "pk": 175}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20016"}, "model": "locality.zipcode", "pk": 176}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90723"}, "model": "locality.zipcode", "pk": 177}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94402"}, "model": "locality.zipcode", "pk": 178}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33626"}, "model": "locality.zipcode", "pk": 179}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90606"}, "model": "locality.zipcode", "pk": 180}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95618"}, "model": "locality.zipcode", "pk": 181}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90043"}, "model": "locality.zipcode", "pk": 182}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94707"}, "model": "locality.zipcode", "pk": 183}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94061"}, "model": "locality.zipcode", "pk": 184}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90254"}, "model": "locality.zipcode", "pk": 185}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95815"}, "model": "locality.zipcode", "pk": 186}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89108"}, "model": "locality.zipcode", "pk": 187}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90640"}, "model": "locality.zipcode", "pk": 188}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94127"}, "model": "locality.zipcode", "pk": 189}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34986"}, "model": "locality.zipcode", "pk": 190}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90209"}, "model": "locality.zipcode", "pk": 191}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95822"}, "model": "locality.zipcode", "pk": 192}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91604"}, "model": "locality.zipcode", "pk": 193}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92018"}, "model": "locality.zipcode", "pk": 194}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90036"}, "model": "locality.zipcode", "pk": 195}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33141"}, "model": "locality.zipcode", "pk": 196}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92867"}, "model": "locality.zipcode", "pk": 197}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94158"}, "model": "locality.zipcode", "pk": 198}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93116"}, "model": "locality.zipcode", "pk": 199}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95818"}, "model": "locality.zipcode", "pk": 200}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92805"}, "model": "locality.zipcode", "pk": 201}, {"fields": {"county": null, "city": null, "state": 132, "name": null, "short_name": "70163"}, "model": "locality.zipcode", "pk": 202}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92705"}, "model": "locality.zipcode", "pk": 203}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92170"}, "model": "locality.zipcode", "pk": 204}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94549"}, "model": "locality.zipcode", "pk": 205}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94611"}, "model": "locality.zipcode", "pk": 206}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "61201"}, "model": "locality.zipcode", "pk": 207}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91801"}, "model": "locality.zipcode", "pk": 208}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20852"}, "model": "locality.zipcode", "pk": 209}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94129"}, "model": "locality.zipcode", "pk": 210}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94542"}, "model": "locality.zipcode", "pk": 211}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90011"}, "model": "locality.zipcode", "pk": 212}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95758"}, "model": "locality.zipcode", "pk": 213}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90045"}, "model": "locality.zipcode", "pk": 214}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92804"}, "model": "locality.zipcode", "pk": 215}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92831"}, "model": "locality.zipcode", "pk": 216}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90004"}, "model": "locality.zipcode", "pk": 217}, {"fields": {"county": null, "city": null, "state": 142, "name": null, "short_name": "44122"}, "model": "locality.zipcode", "pk": 218}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90713"}, "model": "locality.zipcode", "pk": 219}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92166"}, "model": "locality.zipcode", "pk": 220}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94920"}, "model": "locality.zipcode", "pk": 221}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94043"}, "model": "locality.zipcode", "pk": 222}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92138"}, "model": "locality.zipcode", "pk": 223}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91106"}, "model": "locality.zipcode", "pk": 224}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94025"}, "model": "locality.zipcode", "pk": 225}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92701"}, "model": "locality.zipcode", "pk": 226}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92651"}, "model": "locality.zipcode", "pk": 227}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94110"}, "model": "locality.zipcode", "pk": 228}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20004"}, "model": "locality.zipcode", "pk": 229}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92192"}, "model": "locality.zipcode", "pk": 230}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95691"}, "model": "locality.zipcode", "pk": 231}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95817"}, "model": "locality.zipcode", "pk": 232}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90245"}, "model": "locality.zipcode", "pk": 233}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90013"}, "model": "locality.zipcode", "pk": 234}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20036"}, "model": "locality.zipcode", "pk": 235}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90622"}, "model": "locality.zipcode", "pk": 236}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21401"}, "model": "locality.zipcode", "pk": 237}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90057"}, "model": "locality.zipcode", "pk": 238}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94612"}, "model": "locality.zipcode", "pk": 239}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20006"}, "model": "locality.zipcode", "pk": 240}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20001"}, "model": "locality.zipcode", "pk": 241}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94609"}, "model": "locality.zipcode", "pk": 242}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91731"}, "model": "locality.zipcode", "pk": 243}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89031"}, "model": "locality.zipcode", "pk": 244}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10003"}, "model": "locality.zipcode", "pk": 245}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92882"}, "model": "locality.zipcode", "pk": 246}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92612"}, "model": "locality.zipcode", "pk": 247}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90806"}, "model": "locality.zipcode", "pk": 248}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90059"}, "model": "locality.zipcode", "pk": 249}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90703"}, "model": "locality.zipcode", "pk": 250}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95687"}, "model": "locality.zipcode", "pk": 251}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90621"}, "model": "locality.zipcode", "pk": 252}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92083"}, "model": "locality.zipcode", "pk": 253}, {"fields": {"county": null, "city": null, "state": 159, "name": null, "short_name": "46032"}, "model": "locality.zipcode", "pk": 254}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92176"}, "model": "locality.zipcode", "pk": 255}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95811"}, "model": "locality.zipcode", "pk": 256}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60148"}, "model": "locality.zipcode", "pk": 257}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94819"}, "model": "locality.zipcode", "pk": 258}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30306"}, "model": "locality.zipcode", "pk": 259}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02114"}, "model": "locality.zipcode", "pk": 260}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92679"}, "model": "locality.zipcode", "pk": 261}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91912"}, "model": "locality.zipcode", "pk": 262}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30076"}, "model": "locality.zipcode", "pk": 263}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90040"}, "model": "locality.zipcode", "pk": 264}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92806"}, "model": "locality.zipcode", "pk": 265}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23513"}, "model": "locality.zipcode", "pk": 266}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94804"}, "model": "locality.zipcode", "pk": 267}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98144"}, "model": "locality.zipcode", "pk": 268}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95816"}, "model": "locality.zipcode", "pk": 269}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90005"}, "model": "locality.zipcode", "pk": 270}, {"fields": {"county": null, "city": null, "state": 169, "name": null, "short_name": "18985"}, "model": "locality.zipcode", "pk": 271}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96701"}, "model": "locality.zipcode", "pk": 272}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90023"}, "model": "locality.zipcode", "pk": 273}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22202"}, "model": "locality.zipcode", "pk": 274}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98056"}, "model": "locality.zipcode", "pk": 275}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92284"}, "model": "locality.zipcode", "pk": 276}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22181"}, "model": "locality.zipcode", "pk": 277}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60010"}, "model": "locality.zipcode", "pk": 278}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91776"}, "model": "locality.zipcode", "pk": 279}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92028"}, "model": "locality.zipcode", "pk": 280}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "20171"}, "model": "locality.zipcode", "pk": 281}, {"fields": {"county": null, "city": null, "state": 181, "name": null, "short_name": "68145"}, "model": "locality.zipcode", "pk": 282}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10022"}, "model": "locality.zipcode", "pk": 283}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32789"}, "model": "locality.zipcode", "pk": 284}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32806"}, "model": "locality.zipcode", "pk": 285}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34744"}, "model": "locality.zipcode", "pk": 286}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32833"}, "model": "locality.zipcode", "pk": 287}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34741"}, "model": "locality.zipcode", "pk": 288}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75201"}, "model": "locality.zipcode", "pk": 289}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90501"}, "model": "locality.zipcode", "pk": 290}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89118"}, "model": "locality.zipcode", "pk": 291}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75062"}, "model": "locality.zipcode", "pk": 292}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60603"}, "model": "locality.zipcode", "pk": 293}, {"fields": {"county": null, "city": null, "state": 190, "name": null, "short_name": "29550"}, "model": "locality.zipcode", "pk": 294}, {"fields": {"county": null, "city": null, "state": 192, "name": null, "short_name": "72716"}, "model": "locality.zipcode", "pk": 295}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90071"}, "model": "locality.zipcode", "pk": 296}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91764"}, "model": "locality.zipcode", "pk": 297}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92060"}, "model": "locality.zipcode", "pk": 298}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92590"}, "model": "locality.zipcode", "pk": 299}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92675"}, "model": "locality.zipcode", "pk": 300}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92596"}, "model": "locality.zipcode", "pk": 301}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94301"}, "model": "locality.zipcode", "pk": 302}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "89158"}, "model": "locality.zipcode", "pk": 303}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92038"}, "model": "locality.zipcode", "pk": 304}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94123"}, "model": "locality.zipcode", "pk": 305}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89135"}, "model": "locality.zipcode", "pk": 306}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23321"}, "model": "locality.zipcode", "pk": 307}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "89169"}, "model": "locality.zipcode", "pk": 308}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89158"}, "model": "locality.zipcode", "pk": 309}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92629"}, "model": "locality.zipcode", "pk": 310}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89107"}, "model": "locality.zipcode", "pk": 311}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91505"}, "model": "locality.zipcode", "pk": 312}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94577"}, "model": "locality.zipcode", "pk": 313}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92163"}, "model": "locality.zipcode", "pk": 314}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90212"}, "model": "locality.zipcode", "pk": 315}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91908"}, "model": "locality.zipcode", "pk": 316}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91403"}, "model": "locality.zipcode", "pk": 317}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95490"}, "model": "locality.zipcode", "pk": 318}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92173"}, "model": "locality.zipcode", "pk": 319}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90069"}, "model": "locality.zipcode", "pk": 320}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33024"}, "model": "locality.zipcode", "pk": 321}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92243"}, "model": "locality.zipcode", "pk": 322}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85255"}, "model": "locality.zipcode", "pk": 323}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20017"}, "model": "locality.zipcode", "pk": 324}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78216"}, "model": "locality.zipcode", "pk": 325}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91803"}, "model": "locality.zipcode", "pk": 326}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92649"}, "model": "locality.zipcode", "pk": 327}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90015"}, "model": "locality.zipcode", "pk": 328}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20009"}, "model": "locality.zipcode", "pk": 329}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91405"}, "model": "locality.zipcode", "pk": 330}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10034"}, "model": "locality.zipcode", "pk": 331}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92255"}, "model": "locality.zipcode", "pk": 332}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92039"}, "model": "locality.zipcode", "pk": 333}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33317"}, "model": "locality.zipcode", "pk": 334}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92602"}, "model": "locality.zipcode", "pk": 335}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22207"}, "model": "locality.zipcode", "pk": 336}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92167"}, "model": "locality.zipcode", "pk": 337}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90012"}, "model": "locality.zipcode", "pk": 338}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95683"}, "model": "locality.zipcode", "pk": 339}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93033"}, "model": "locality.zipcode", "pk": 340}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90001"}, "model": "locality.zipcode", "pk": 341}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92250"}, "model": "locality.zipcode", "pk": 342}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91101"}, "model": "locality.zipcode", "pk": 343}, {"fields": {"county": null, "city": null, "state": 159, "name": null, "short_name": "46526"}, "model": "locality.zipcode", "pk": 344}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90620"}, "model": "locality.zipcode", "pk": 345}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91607"}, "model": "locality.zipcode", "pk": 346}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02446"}, "model": "locality.zipcode", "pk": 347}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90019"}, "model": "locality.zipcode", "pk": 348}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94610"}, "model": "locality.zipcode", "pk": 349}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98122"}, "model": "locality.zipcode", "pk": 350}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90067"}, "model": "locality.zipcode", "pk": 351}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20037"}, "model": "locality.zipcode", "pk": 352}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91761"}, "model": "locality.zipcode", "pk": 353}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91335"}, "model": "locality.zipcode", "pk": 354}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92234"}, "model": "locality.zipcode", "pk": 355}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92706"}, "model": "locality.zipcode", "pk": 356}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90049"}, "model": "locality.zipcode", "pk": 357}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94501"}, "model": "locality.zipcode", "pk": 358}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93101"}, "model": "locality.zipcode", "pk": 359}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95106"}, "model": "locality.zipcode", "pk": 360}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98040"}, "model": "locality.zipcode", "pk": 361}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "22760"}, "model": "locality.zipcode", "pk": 362}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94002"}, "model": "locality.zipcode", "pk": 363}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98101"}, "model": "locality.zipcode", "pk": 364}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23324"}, "model": "locality.zipcode", "pk": 365}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94608"}, "model": "locality.zipcode", "pk": 366}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23607"}, "model": "locality.zipcode", "pk": 367}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92356"}, "model": "locality.zipcode", "pk": 368}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "Unknown-Zip"}, "model": "locality.zipcode", "pk": 369}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06840"}, "model": "locality.zipcode", "pk": 370}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94109"}, "model": "locality.zipcode", "pk": 371}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92017"}, "model": "locality.zipcode", "pk": 372}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85260"}, "model": "locality.zipcode", "pk": 373}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06437"}, "model": "locality.zipcode", "pk": 374}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "64113"}, "model": "locality.zipcode", "pk": 375}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11218"}, "model": "locality.zipcode", "pk": 376}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90272"}, "model": "locality.zipcode", "pk": 377}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34223"}, "model": "locality.zipcode", "pk": 378}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94566"}, "model": "locality.zipcode", "pk": 379}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92013"}, "model": "locality.zipcode", "pk": 380}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90291"}, "model": "locality.zipcode", "pk": 381}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95945"}, "model": "locality.zipcode", "pk": 382}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92171"}, "model": "locality.zipcode", "pk": 383}, {"fields": {"county": null, "city": null, "state": 244, "name": null, "short_name": "00000"}, "model": "locality.zipcode", "pk": 384}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91108"}, "model": "locality.zipcode", "pk": 385}, {"fields": {"county": null, "city": null, "state": 192, "name": null, "short_name": "72223"}, "model": "locality.zipcode", "pk": 386}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94965"}, "model": "locality.zipcode", "pk": 387}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96819"}, "model": "locality.zipcode", "pk": 388}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96814"}, "model": "locality.zipcode", "pk": 389}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91711"}, "model": "locality.zipcode", "pk": 390}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92646"}, "model": "locality.zipcode", "pk": 391}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96821"}, "model": "locality.zipcode", "pk": 392}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02119"}, "model": "locality.zipcode", "pk": 393}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91906"}, "model": "locality.zipcode", "pk": 394}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92253"}, "model": "locality.zipcode", "pk": 395}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90232"}, "model": "locality.zipcode", "pk": 396}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30107"}, "model": "locality.zipcode", "pk": 397}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92672"}, "model": "locality.zipcode", "pk": 398}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91202"}, "model": "locality.zipcode", "pk": 399}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95949"}, "model": "locality.zipcode", "pk": 400}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98103"}, "model": "locality.zipcode", "pk": 401}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85281"}, "model": "locality.zipcode", "pk": 402}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60047"}, "model": "locality.zipcode", "pk": 403}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92625"}, "model": "locality.zipcode", "pk": 404}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30068"}, "model": "locality.zipcode", "pk": 405}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93011"}, "model": "locality.zipcode", "pk": 406}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90039"}, "model": "locality.zipcode", "pk": 407}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91302"}, "model": "locality.zipcode", "pk": 408}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91006"}, "model": "locality.zipcode", "pk": 409}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75230"}, "model": "locality.zipcode", "pk": 410}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94010"}, "model": "locality.zipcode", "pk": 411}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92835"}, "model": "locality.zipcode", "pk": 412}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30024"}, "model": "locality.zipcode", "pk": 413}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "31024"}, "model": "locality.zipcode", "pk": 414}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96732"}, "model": "locality.zipcode", "pk": 415}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94582"}, "model": "locality.zipcode", "pk": 416}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93023"}, "model": "locality.zipcode", "pk": 417}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90248"}, "model": "locality.zipcode", "pk": 418}, {"fields": {"county": null, "city": null, "state": 273, "name": null, "short_name": "55421"}, "model": "locality.zipcode", "pk": 419}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02675"}, "model": "locality.zipcode", "pk": 420}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92808"}, "model": "locality.zipcode", "pk": 421}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92155"}, "model": "locality.zipcode", "pk": 422}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75205"}, "model": "locality.zipcode", "pk": 423}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75214"}, "model": "locality.zipcode", "pk": 424}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91730"}, "model": "locality.zipcode", "pk": 425}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89451"}, "model": "locality.zipcode", "pk": 426}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92671"}, "model": "locality.zipcode", "pk": 427}, {"fields": {"county": null, "city": null, "state": 281, "name": null, "short_name": "25314"}, "model": "locality.zipcode", "pk": 428}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94563"}, "model": "locality.zipcode", "pk": 429}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20002"}, "model": "locality.zipcode", "pk": 430}, {"fields": {"county": null, "city": null, "state": 284, "name": null, "short_name": "37067"}, "model": "locality.zipcode", "pk": 431}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94530"}, "model": "locality.zipcode", "pk": 432}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89119"}, "model": "locality.zipcode", "pk": 433}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30004"}, "model": "locality.zipcode", "pk": 434}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94545"}, "model": "locality.zipcode", "pk": 435}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90265"}, "model": "locality.zipcode", "pk": 436}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96734"}, "model": "locality.zipcode", "pk": 437}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96822"}, "model": "locality.zipcode", "pk": 438}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92782"}, "model": "locality.zipcode", "pk": 439}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96813"}, "model": "locality.zipcode", "pk": 440}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91916"}, "model": "locality.zipcode", "pk": 441}, {"fields": {"county": null, "city": null, "state": 85, "name": null, "short_name": "83014"}, "model": "locality.zipcode", "pk": 442}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80132"}, "model": "locality.zipcode", "pk": 443}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95124"}, "model": "locality.zipcode", "pk": 444}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92624"}, "model": "locality.zipcode", "pk": 445}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77069"}, "model": "locality.zipcode", "pk": 446}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94903"}, "model": "locality.zipcode", "pk": 447}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92870"}, "model": "locality.zipcode", "pk": 448}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89102"}, "model": "locality.zipcode", "pk": 449}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90277"}, "model": "locality.zipcode", "pk": 450}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80246"}, "model": "locality.zipcode", "pk": 451}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20814"}, "model": "locality.zipcode", "pk": 452}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23227"}, "model": "locality.zipcode", "pk": 453}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92587"}, "model": "locality.zipcode", "pk": 454}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96825"}, "model": "locality.zipcode", "pk": 455}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89169"}, "model": "locality.zipcode", "pk": 456}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96815"}, "model": "locality.zipcode", "pk": 457}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92653"}, "model": "locality.zipcode", "pk": 458}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92003"}, "model": "locality.zipcode", "pk": 459}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "62704"}, "model": "locality.zipcode", "pk": 460}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90010"}, "model": "locality.zipcode", "pk": 461}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91903"}, "model": "locality.zipcode", "pk": 462}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85048"}, "model": "locality.zipcode", "pk": 463}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60045"}, "model": "locality.zipcode", "pk": 464}, {"fields": {"county": null, "city": null, "state": 305, "name": null, "short_name": "73112"}, "model": "locality.zipcode", "pk": 465}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92210"}, "model": "locality.zipcode", "pk": 466}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92134"}, "model": "locality.zipcode", "pk": 467}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20901"}, "model": "locality.zipcode", "pk": 468}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11516"}, "model": "locality.zipcode", "pk": 469}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92164"}, "model": "locality.zipcode", "pk": 470}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89106"}, "model": "locality.zipcode", "pk": 471}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91436"}, "model": "locality.zipcode", "pk": 472}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02140"}, "model": "locality.zipcode", "pk": 473}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90630"}, "model": "locality.zipcode", "pk": 474}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60440"}, "model": "locality.zipcode", "pk": 475}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91411"}, "model": "locality.zipcode", "pk": 476}, {"fields": {"county": null, "city": null, "state": 313, "name": null, "short_name": "N1 4DJ"}, "model": "locality.zipcode", "pk": 477}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02142"}, "model": "locality.zipcode", "pk": 478}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94022"}, "model": "locality.zipcode", "pk": 479}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22134"}, "model": "locality.zipcode", "pk": 480}, {"fields": {"county": null, "city": null, "state": 190, "name": null, "short_name": "29307"}, "model": "locality.zipcode", "pk": 481}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22932"}, "model": "locality.zipcode", "pk": 482}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97217"}, "model": "locality.zipcode", "pk": 483}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90660"}, "model": "locality.zipcode", "pk": 484}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92507"}, "model": "locality.zipcode", "pk": 485}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92316"}, "model": "locality.zipcode", "pk": 486}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95131"}, "model": "locality.zipcode", "pk": 487}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91768"}, "model": "locality.zipcode", "pk": 488}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21076"}, "model": "locality.zipcode", "pk": 489}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80013"}, "model": "locality.zipcode", "pk": 490}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80237"}, "model": "locality.zipcode", "pk": 491}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19103"}, "model": "locality.zipcode", "pk": 492}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90670"}, "model": "locality.zipcode", "pk": 493}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92211"}, "model": "locality.zipcode", "pk": 494}, {"fields": {"county": null, "city": null, "state": 328, "name": null, "short_name": "84098"}, "model": "locality.zipcode", "pk": 495}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60173"}, "model": "locality.zipcode", "pk": 496}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92630"}, "model": "locality.zipcode", "pk": 497}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92656"}, "model": "locality.zipcode", "pk": 498}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85268"}, "model": "locality.zipcode", "pk": 499}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "64014"}, "model": "locality.zipcode", "pk": 500}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94588"}, "model": "locality.zipcode", "pk": 501}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94510"}, "model": "locality.zipcode", "pk": 502}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77027"}, "model": "locality.zipcode", "pk": 503}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80303"}, "model": "locality.zipcode", "pk": 504}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90623"}, "model": "locality.zipcode", "pk": 505}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92399"}, "model": "locality.zipcode", "pk": 506}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95834"}, "model": "locality.zipcode", "pk": 507}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02451"}, "model": "locality.zipcode", "pk": 508}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94118"}, "model": "locality.zipcode", "pk": 509}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91355"}, "model": "locality.zipcode", "pk": 510}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95467"}, "model": "locality.zipcode", "pk": 511}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93012"}, "model": "locality.zipcode", "pk": 512}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92570"}, "model": "locality.zipcode", "pk": 513}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33316"}, "model": "locality.zipcode", "pk": 514}, {"fields": {"county": null, "city": null, "state": 85, "name": null, "short_name": "83001"}, "model": "locality.zipcode", "pk": 515}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92563"}, "model": "locality.zipcode", "pk": 516}, {"fields": {"county": null, "city": null, "state": 343, "name": null, "short_name": "53212"}, "model": "locality.zipcode", "pk": 517}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95841"}, "model": "locality.zipcode", "pk": 518}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90034"}, "model": "locality.zipcode", "pk": 519}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91356"}, "model": "locality.zipcode", "pk": 520}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91316"}, "model": "locality.zipcode", "pk": 521}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11205"}, "model": "locality.zipcode", "pk": 522}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94526"}, "model": "locality.zipcode", "pk": 523}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85623"}, "model": "locality.zipcode", "pk": 524}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90266"}, "model": "locality.zipcode", "pk": 525}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90402"}, "model": "locality.zipcode", "pk": 526}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94070"}, "model": "locality.zipcode", "pk": 527}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90731"}, "model": "locality.zipcode", "pk": 528}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94941"}, "model": "locality.zipcode", "pk": 529}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80212"}, "model": "locality.zipcode", "pk": 530}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90405"}, "model": "locality.zipcode", "pk": 531}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91001"}, "model": "locality.zipcode", "pk": 532}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92506"}, "model": "locality.zipcode", "pk": 533}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91944"}, "model": "locality.zipcode", "pk": 534}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92868"}, "model": "locality.zipcode", "pk": 535}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91752"}, "model": "locality.zipcode", "pk": 536}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92880"}, "model": "locality.zipcode", "pk": 537}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92585"}, "model": "locality.zipcode", "pk": 538}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90017"}, "model": "locality.zipcode", "pk": 539}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75240"}, "model": "locality.zipcode", "pk": 540}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "96001"}, "model": "locality.zipcode", "pk": 541}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92626"}, "model": "locality.zipcode", "pk": 542}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94108"}, "model": "locality.zipcode", "pk": 543}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95826"}, "model": "locality.zipcode", "pk": 544}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92707"}, "model": "locality.zipcode", "pk": 545}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92618"}, "model": "locality.zipcode", "pk": 546}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32819"}, "model": "locality.zipcode", "pk": 547}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90807"}, "model": "locality.zipcode", "pk": 548}, {"fields": {"county": null, "city": null, "state": 359, "name": null, "short_name": "75015"}, "model": "locality.zipcode", "pk": 549}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77019"}, "model": "locality.zipcode", "pk": 550}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94131"}, "model": "locality.zipcode", "pk": 551}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94558"}, "model": "locality.zipcode", "pk": 552}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85018"}, "model": "locality.zipcode", "pk": 553}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92606"}, "model": "locality.zipcode", "pk": 554}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90803"}, "model": "locality.zipcode", "pk": 555}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92692"}, "model": "locality.zipcode", "pk": 556}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92408"}, "model": "locality.zipcode", "pk": 557}, {"fields": {"county": null, "city": null, "state": 364, "name": null, "short_name": "66219"}, "model": "locality.zipcode", "pk": 558}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85027"}, "model": "locality.zipcode", "pk": 559}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95476"}, "model": "locality.zipcode", "pk": 560}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91011"}, "model": "locality.zipcode", "pk": 561}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "99223"}, "model": "locality.zipcode", "pk": 562}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90740"}, "model": "locality.zipcode", "pk": 563}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80906"}, "model": "locality.zipcode", "pk": 564}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89014"}, "model": "locality.zipcode", "pk": 565}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92688"}, "model": "locality.zipcode", "pk": 566}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85284"}, "model": "locality.zipcode", "pk": 567}, {"fields": {"county": null, "city": null, "state": 364, "name": null, "short_name": "66209"}, "model": "locality.zipcode", "pk": 568}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02054"}, "model": "locality.zipcode", "pk": 569}, {"fields": {"county": null, "city": null, "state": 373, "name": null, "short_name": "39530"}, "model": "locality.zipcode", "pk": 570}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94947"}, "model": "locality.zipcode", "pk": 571}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90706"}, "model": "locality.zipcode", "pk": 572}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02135"}, "model": "locality.zipcode", "pk": 573}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32832"}, "model": "locality.zipcode", "pk": 574}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23452"}, "model": "locality.zipcode", "pk": 575}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85266"}, "model": "locality.zipcode", "pk": 576}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92036"}, "model": "locality.zipcode", "pk": 577}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90024"}, "model": "locality.zipcode", "pk": 578}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77098"}, "model": "locality.zipcode", "pk": 579}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85024"}, "model": "locality.zipcode", "pk": 580}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91601"}, "model": "locality.zipcode", "pk": 581}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06277"}, "model": "locality.zipcode", "pk": 582}, {"fields": {"county": null, "city": null, "state": 381, "name": null, "short_name": "03229"}, "model": "locality.zipcode", "pk": 583}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90027"}, "model": "locality.zipcode", "pk": 584}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90068"}, "model": "locality.zipcode", "pk": 585}, {"fields": {"county": null, "city": null, "state": 383, "name": null, "short_name": "40502"}, "model": "locality.zipcode", "pk": 586}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91344"}, "model": "locality.zipcode", "pk": 587}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98126"}, "model": "locality.zipcode", "pk": 588}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98074"}, "model": "locality.zipcode", "pk": 589}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91750"}, "model": "locality.zipcode", "pk": 590}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90042"}, "model": "locality.zipcode", "pk": 591}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21113"}, "model": "locality.zipcode", "pk": 592}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93060"}, "model": "locality.zipcode", "pk": 593}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20010"}, "model": "locality.zipcode", "pk": 594}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80228"}, "model": "locality.zipcode", "pk": 595}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11238"}, "model": "locality.zipcode", "pk": 596}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94805"}, "model": "locality.zipcode", "pk": 597}, {"fields": {"county": null, "city": null, "state": 392, "name": null, "short_name": "58704"}, "model": "locality.zipcode", "pk": 598}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92175"}, "model": "locality.zipcode", "pk": 599}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97701"}, "model": "locality.zipcode", "pk": 600}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "79606"}, "model": "locality.zipcode", "pk": 601}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "76067"}, "model": "locality.zipcode", "pk": 602}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77006"}, "model": "locality.zipcode", "pk": 603}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92307"}, "model": "locality.zipcode", "pk": 604}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95829"}, "model": "locality.zipcode", "pk": 605}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95032"}, "model": "locality.zipcode", "pk": 606}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90260"}, "model": "locality.zipcode", "pk": 607}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33647"}, "model": "locality.zipcode", "pk": 608}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22102"}, "model": "locality.zipcode", "pk": 609}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33609"}, "model": "locality.zipcode", "pk": 610}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93546"}, "model": "locality.zipcode", "pk": 611}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33615"}, "model": "locality.zipcode", "pk": 612}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91362"}, "model": "locality.zipcode", "pk": 613}, {"fields": {"county": null, "city": null, "state": 273, "name": null, "short_name": "55416"}, "model": "locality.zipcode", "pk": 614}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80465"}, "model": "locality.zipcode", "pk": 615}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92592"}, "model": "locality.zipcode", "pk": 616}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94556"}, "model": "locality.zipcode", "pk": 617}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19104"}, "model": "locality.zipcode", "pk": 618}, {"fields": {"county": null, "city": null, "state": 408, "name": null, "short_name": "05849"}, "model": "locality.zipcode", "pk": 619}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06371"}, "model": "locality.zipcode", "pk": 620}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94925"}, "model": "locality.zipcode", "pk": 621}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94122"}, "model": "locality.zipcode", "pk": 622}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "92009"}, "model": "locality.zipcode", "pk": 623}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80302"}, "model": "locality.zipcode", "pk": 624}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94065"}, "model": "locality.zipcode", "pk": 625}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85742"}, "model": "locality.zipcode", "pk": 626}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "01420"}, "model": "locality.zipcode", "pk": 627}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93420"}, "model": "locality.zipcode", "pk": 628}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95382"}, "model": "locality.zipcode", "pk": 629}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78207"}, "model": "locality.zipcode", "pk": 630}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90601"}, "model": "locality.zipcode", "pk": 631}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93304"}, "model": "locality.zipcode", "pk": 632}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93280"}, "model": "locality.zipcode", "pk": 633}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93311"}, "model": "locality.zipcode", "pk": 634}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95620"}, "model": "locality.zipcode", "pk": 635}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95219"}, "model": "locality.zipcode", "pk": 636}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95338"}, "model": "locality.zipcode", "pk": 637}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94506"}, "model": "locality.zipcode", "pk": 638}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77077"}, "model": "locality.zipcode", "pk": 639}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95202"}, "model": "locality.zipcode", "pk": 640}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77009"}, "model": "locality.zipcode", "pk": 641}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93263"}, "model": "locality.zipcode", "pk": 642}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92627"}, "model": "locality.zipcode", "pk": 643}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90301"}, "model": "locality.zipcode", "pk": 644}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91905"}, "model": "locality.zipcode", "pk": 645}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92112"}, "model": "locality.zipcode", "pk": 646}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93308"}, "model": "locality.zipcode", "pk": 647}, {"fields": {"county": null, "city": null, "state": 172, "name": null, "short_name": "96839"}, "model": "locality.zipcode", "pk": 648}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91948"}, "model": "locality.zipcode", "pk": 649}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78228"}, "model": "locality.zipcode", "pk": 650}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92023"}, "model": "locality.zipcode", "pk": 651}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92536"}, "model": "locality.zipcode", "pk": 652}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94116"}, "model": "locality.zipcode", "pk": 653}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94103"}, "model": "locality.zipcode", "pk": 654}, {"fields": {"county": null, "city": null, "state": 428, "name": null, "short_name": "V5C 3B8"}, "model": "locality.zipcode", "pk": 655}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92059"}, "model": "locality.zipcode", "pk": 656}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92061"}, "model": "locality.zipcode", "pk": 657}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10027"}, "model": "locality.zipcode", "pk": 658}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11201"}, "model": "locality.zipcode", "pk": 659}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92539"}, "model": "locality.zipcode", "pk": 660}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94607"}, "model": "locality.zipcode", "pk": 661}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93109"}, "model": "locality.zipcode", "pk": 662}, {"fields": {"county": null, "city": null, "state": 432, "name": null, "short_name": "19805"}, "model": "locality.zipcode", "pk": 663}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10570"}, "model": "locality.zipcode", "pk": 664}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98102"}, "model": "locality.zipcode", "pk": 665}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32205"}, "model": "locality.zipcode", "pk": 666}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95757"}, "model": "locality.zipcode", "pk": 667}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "8234"}, "model": "locality.zipcode", "pk": 668}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "2155"}, "model": "locality.zipcode", "pk": 669}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23235"}, "model": "locality.zipcode", "pk": 670}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85016"}, "model": "locality.zipcode", "pk": 671}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20815"}, "model": "locality.zipcode", "pk": 672}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10023"}, "model": "locality.zipcode", "pk": 673}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19063"}, "model": "locality.zipcode", "pk": 674}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "49250"}, "model": "locality.zipcode", "pk": 675}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93292"}, "model": "locality.zipcode", "pk": 676}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10987"}, "model": "locality.zipcode", "pk": 677}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "08742"}, "model": "locality.zipcode", "pk": 678}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89445"}, "model": "locality.zipcode", "pk": 679}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90230"}, "model": "locality.zipcode", "pk": 680}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91423"}, "model": "locality.zipcode", "pk": 681}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89052"}, "model": "locality.zipcode", "pk": 682}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94132"}, "model": "locality.zipcode", "pk": 683}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80220"}, "model": "locality.zipcode", "pk": 684}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60540"}, "model": "locality.zipcode", "pk": 685}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90077"}, "model": "locality.zipcode", "pk": 686}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75229"}, "model": "locality.zipcode", "pk": 687}, {"fields": {"county": null, "city": null, "state": 132, "name": null, "short_name": "70124"}, "model": "locality.zipcode", "pk": 688}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30305"}, "model": "locality.zipcode", "pk": 689}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95113"}, "model": "locality.zipcode", "pk": 690}, {"fields": {"county": null, "city": null, "state": 273, "name": null, "short_name": "55403"}, "model": "locality.zipcode", "pk": 691}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60615"}, "model": "locality.zipcode", "pk": 692}, {"fields": {"county": null, "city": null, "state": 190, "name": null, "short_name": "29681"}, "model": "locality.zipcode", "pk": 693}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60641"}, "model": "locality.zipcode", "pk": 694}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91920"}, "model": "locality.zipcode", "pk": 695}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92549"}, "model": "locality.zipcode", "pk": 696}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10007"}, "model": "locality.zipcode", "pk": 697}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90094"}, "model": "locality.zipcode", "pk": 698}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "96161"}, "model": "locality.zipcode", "pk": 699}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90220"}, "model": "locality.zipcode", "pk": 700}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95448"}, "model": "locality.zipcode", "pk": 701}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93117"}, "model": "locality.zipcode", "pk": 702}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91340"}, "model": "locality.zipcode", "pk": 703}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "48323"}, "model": "locality.zipcode", "pk": 704}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33140"}, "model": "locality.zipcode", "pk": 705}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91921"}, "model": "locality.zipcode", "pk": 706}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "99362"}, "model": "locality.zipcode", "pk": 707}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93065"}, "model": "locality.zipcode", "pk": 708}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60622"}, "model": "locality.zipcode", "pk": 709}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89101"}, "model": "locality.zipcode", "pk": 710}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93728"}, "model": "locality.zipcode", "pk": 711}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78757"}, "model": "locality.zipcode", "pk": 712}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75647"}, "model": "locality.zipcode", "pk": 713}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33178"}, "model": "locality.zipcode", "pk": 714}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22205"}, "model": "locality.zipcode", "pk": 715}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97702"}, "model": "locality.zipcode", "pk": 716}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92861"}, "model": "locality.zipcode", "pk": 717}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19422"}, "model": "locality.zipcode", "pk": 718}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97229"}, "model": "locality.zipcode", "pk": 719}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10549"}, "model": "locality.zipcode", "pk": 720}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94708"}, "model": "locality.zipcode", "pk": 721}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06897"}, "model": "locality.zipcode", "pk": 722}, {"fields": {"county": null, "city": null, "state": 99, "name": null, "short_name": "83814"}, "model": "locality.zipcode", "pk": 723}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97068"}, "model": "locality.zipcode", "pk": 724}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91381"}, "model": "locality.zipcode", "pk": 725}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91709"}, "model": "locality.zipcode", "pk": 726}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02468"}, "model": "locality.zipcode", "pk": 727}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91107"}, "model": "locality.zipcode", "pk": 728}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85331"}, "model": "locality.zipcode", "pk": 729}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85254"}, "model": "locality.zipcode", "pk": 730}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93401"}, "model": "locality.zipcode", "pk": 731}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10028"}, "model": "locality.zipcode", "pk": 732}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20011"}, "model": "locality.zipcode", "pk": 733}, {"fields": {"county": null, "city": null, "state": 313, "name": null, "short_name": "SW1W8JT"}, "model": "locality.zipcode", "pk": 734}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10573"}, "model": "locality.zipcode", "pk": 735}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33157"}, "model": "locality.zipcode", "pk": 736}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75703"}, "model": "locality.zipcode", "pk": 737}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "07452"}, "model": "locality.zipcode", "pk": 738}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "08810"}, "model": "locality.zipcode", "pk": 739}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10013"}, "model": "locality.zipcode", "pk": 740}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90249"}, "model": "locality.zipcode", "pk": 741}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78626"}, "model": "locality.zipcode", "pk": 742}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94041"}, "model": "locality.zipcode", "pk": 743}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93950"}, "model": "locality.zipcode", "pk": 744}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92615"}, "model": "locality.zipcode", "pk": 745}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94915"}, "model": "locality.zipcode", "pk": 746}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91311"}, "model": "locality.zipcode", "pk": 747}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91701"}, "model": "locality.zipcode", "pk": 748}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91214"}, "model": "locality.zipcode", "pk": 749}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92708"}, "model": "locality.zipcode", "pk": 750}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92610"}, "model": "locality.zipcode", "pk": 751}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89061"}, "model": "locality.zipcode", "pk": 752}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91350"}, "model": "locality.zipcode", "pk": 753}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93103"}, "model": "locality.zipcode", "pk": 754}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94619"}, "model": "locality.zipcode", "pk": 755}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90028"}, "model": "locality.zipcode", "pk": 756}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94574"}, "model": "locality.zipcode", "pk": 757}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "64502"}, "model": "locality.zipcode", "pk": 758}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94602"}, "model": "locality.zipcode", "pk": 759}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94102"}, "model": "locality.zipcode", "pk": 760}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94531"}, "model": "locality.zipcode", "pk": 761}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94606"}, "model": "locality.zipcode", "pk": 762}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94605"}, "model": "locality.zipcode", "pk": 763}, {"fields": {"county": null, "city": null, "state": 494, "name": null, "short_name": "59715"}, "model": "locality.zipcode", "pk": 764}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94014"}, "model": "locality.zipcode", "pk": 765}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94706"}, "model": "locality.zipcode", "pk": 766}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94621"}, "model": "locality.zipcode", "pk": 767}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94115"}, "model": "locality.zipcode", "pk": 768}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94705"}, "model": "locality.zipcode", "pk": 769}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94534"}, "model": "locality.zipcode", "pk": 770}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94564"}, "model": "locality.zipcode", "pk": 771}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94603"}, "model": "locality.zipcode", "pk": 772}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94552"}, "model": "locality.zipcode", "pk": 773}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94555"}, "model": "locality.zipcode", "pk": 774}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94546"}, "model": "locality.zipcode", "pk": 775}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94801"}, "model": "locality.zipcode", "pk": 776}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94547"}, "model": "locality.zipcode", "pk": 777}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94702"}, "model": "locality.zipcode", "pk": 778}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95632"}, "model": "locality.zipcode", "pk": 779}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22201"}, "model": "locality.zipcode", "pk": 780}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "3331"}, "model": "locality.zipcode", "pk": 781}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95125"}, "model": "locality.zipcode", "pk": 782}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94601"}, "model": "locality.zipcode", "pk": 783}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91307"}, "model": "locality.zipcode", "pk": 784}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94502"}, "model": "locality.zipcode", "pk": 785}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94596"}, "model": "locality.zipcode", "pk": 786}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95402"}, "model": "locality.zipcode", "pk": 787}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95126"}, "model": "locality.zipcode", "pk": 788}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94803"}, "model": "locality.zipcode", "pk": 789}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94568"}, "model": "locality.zipcode", "pk": 790}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60134"}, "model": "locality.zipcode", "pk": 791}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95120"}, "model": "locality.zipcode", "pk": 792}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95828"}, "model": "locality.zipcode", "pk": 793}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95608"}, "model": "locality.zipcode", "pk": 794}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93612"}, "model": "locality.zipcode", "pk": 795}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95776"}, "model": "locality.zipcode", "pk": 796}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92186"}, "model": "locality.zipcode", "pk": 797}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95742"}, "model": "locality.zipcode", "pk": 798}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95380"}, "model": "locality.zipcode", "pk": 799}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92223"}, "model": "locality.zipcode", "pk": 800}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95838"}, "model": "locality.zipcode", "pk": 801}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95678"}, "model": "locality.zipcode", "pk": 802}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93291"}, "model": "locality.zipcode", "pk": 803}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90720"}, "model": "locality.zipcode", "pk": 804}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91342"}, "model": "locality.zipcode", "pk": 805}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95403"}, "model": "locality.zipcode", "pk": 806}, {"fields": {"county": null, "city": null, "state": 142, "name": null, "short_name": "43026"}, "model": "locality.zipcode", "pk": 807}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "96101"}, "model": "locality.zipcode", "pk": 808}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94134"}, "model": "locality.zipcode", "pk": 809}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95603"}, "model": "locality.zipcode", "pk": 810}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94066"}, "model": "locality.zipcode", "pk": 811}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91724"}, "model": "locality.zipcode", "pk": 812}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60618"}, "model": "locality.zipcode", "pk": 813}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94578"}, "model": "locality.zipcode", "pk": 814}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94709"}, "model": "locality.zipcode", "pk": 815}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94604"}, "model": "locality.zipcode", "pk": 816}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94806"}, "model": "locality.zipcode", "pk": 817}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94949"}, "model": "locality.zipcode", "pk": 818}, {"fields": {"county": null, "city": null, "state": 392, "name": null, "short_name": "58102"}, "model": "locality.zipcode", "pk": 819}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94704"}, "model": "locality.zipcode", "pk": 820}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "28173"}, "model": "locality.zipcode", "pk": 821}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97031"}, "model": "locality.zipcode", "pk": 822}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94404"}, "model": "locality.zipcode", "pk": 823}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94587"}, "model": "locality.zipcode", "pk": 824}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94523"}, "model": "locality.zipcode", "pk": 825}, {"fields": {"county": null, "city": null, "state": 273, "name": null, "short_name": "55117"}, "model": "locality.zipcode", "pk": 826}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94044"}, "model": "locality.zipcode", "pk": 827}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94087"}, "model": "locality.zipcode", "pk": 828}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94703"}, "model": "locality.zipcode", "pk": 829}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94509"}, "model": "locality.zipcode", "pk": 830}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95070"}, "model": "locality.zipcode", "pk": 831}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95050"}, "model": "locality.zipcode", "pk": 832}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94121"}, "model": "locality.zipcode", "pk": 833}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94541"}, "model": "locality.zipcode", "pk": 834}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94598"}, "model": "locality.zipcode", "pk": 835}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94565"}, "model": "locality.zipcode", "pk": 836}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94595"}, "model": "locality.zipcode", "pk": 837}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06855"}, "model": "locality.zipcode", "pk": 838}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60657"}, "model": "locality.zipcode", "pk": 839}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90035"}, "model": "locality.zipcode", "pk": 840}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23069"}, "model": "locality.zipcode", "pk": 841}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95117"}, "model": "locality.zipcode", "pk": 842}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60613"}, "model": "locality.zipcode", "pk": 843}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60181"}, "model": "locality.zipcode", "pk": 844}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94538"}, "model": "locality.zipcode", "pk": 845}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22046"}, "model": "locality.zipcode", "pk": 846}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "12208"}, "model": "locality.zipcode", "pk": 847}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90503"}, "model": "locality.zipcode", "pk": 848}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94550"}, "model": "locality.zipcode", "pk": 849}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95536"}, "model": "locality.zipcode", "pk": 850}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10035"}, "model": "locality.zipcode", "pk": 851}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94586"}, "model": "locality.zipcode", "pk": 852}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32114"}, "model": "locality.zipcode", "pk": 853}, {"fields": {"county": null, "city": null, "state": 547, "name": null, "short_name": "04102"}, "model": "locality.zipcode", "pk": 854}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87107"}, "model": "locality.zipcode", "pk": 855}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94517"}, "model": "locality.zipcode", "pk": 856}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94901"}, "model": "locality.zipcode", "pk": 857}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95451"}, "model": "locality.zipcode", "pk": 858}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94591"}, "model": "locality.zipcode", "pk": 859}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95441"}, "model": "locality.zipcode", "pk": 860}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94710"}, "model": "locality.zipcode", "pk": 861}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93044"}, "model": "locality.zipcode", "pk": 862}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60626"}, "model": "locality.zipcode", "pk": 863}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80218"}, "model": "locality.zipcode", "pk": 864}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23507"}, "model": "locality.zipcode", "pk": 865}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20854"}, "model": "locality.zipcode", "pk": 866}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92544"}, "model": "locality.zipcode", "pk": 867}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85286"}, "model": "locality.zipcode", "pk": 868}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10707"}, "model": "locality.zipcode", "pk": 869}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78704"}, "model": "locality.zipcode", "pk": 870}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95232"}, "model": "locality.zipcode", "pk": 871}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10708"}, "model": "locality.zipcode", "pk": 872}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94536"}, "model": "locality.zipcode", "pk": 873}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06825"}, "model": "locality.zipcode", "pk": 874}, {"fields": {"county": null, "city": null, "state": 284, "name": null, "short_name": "37212"}, "model": "locality.zipcode", "pk": 875}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94520"}, "model": "locality.zipcode", "pk": 876}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60630"}, "model": "locality.zipcode", "pk": 877}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60605"}, "model": "locality.zipcode", "pk": 878}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22301"}, "model": "locality.zipcode", "pk": 879}, {"fields": {"county": null, "city": null, "state": 284, "name": null, "short_name": "37415"}, "model": "locality.zipcode", "pk": 880}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98467"}, "model": "locality.zipcode", "pk": 881}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60654"}, "model": "locality.zipcode", "pk": 882}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22204"}, "model": "locality.zipcode", "pk": 883}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85251"}, "model": "locality.zipcode", "pk": 884}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30327"}, "model": "locality.zipcode", "pk": 885}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94945"}, "model": "locality.zipcode", "pk": 886}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94024"}, "model": "locality.zipcode", "pk": 887}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94904"}, "model": "locality.zipcode", "pk": 888}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94551"}, "model": "locality.zipcode", "pk": 889}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20720"}, "model": "locality.zipcode", "pk": 890}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94570"}, "model": "locality.zipcode", "pk": 891}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95354"}, "model": "locality.zipcode", "pk": 892}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94303"}, "model": "locality.zipcode", "pk": 893}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94617"}, "model": "locality.zipcode", "pk": 894}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94623"}, "model": "locality.zipcode", "pk": 895}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94015"}, "model": "locality.zipcode", "pk": 896}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94572"}, "model": "locality.zipcode", "pk": 897}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94124"}, "model": "locality.zipcode", "pk": 898}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "63124"}, "model": "locality.zipcode", "pk": 899}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94513"}, "model": "locality.zipcode", "pk": 900}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94912"}, "model": "locality.zipcode", "pk": 901}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94528"}, "model": "locality.zipcode", "pk": 902}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10001"}, "model": "locality.zipcode", "pk": 903}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95825"}, "model": "locality.zipcode", "pk": 904}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94808"}, "model": "locality.zipcode", "pk": 905}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94518"}, "model": "locality.zipcode", "pk": 906}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94614"}, "model": "locality.zipcode", "pk": 907}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95035"}, "model": "locality.zipcode", "pk": 908}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93953"}, "model": "locality.zipcode", "pk": 909}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94112"}, "model": "locality.zipcode", "pk": 910}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95348"}, "model": "locality.zipcode", "pk": 911}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94030"}, "model": "locality.zipcode", "pk": 912}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94597"}, "model": "locality.zipcode", "pk": 913}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90066"}, "model": "locality.zipcode", "pk": 914}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94954"}, "model": "locality.zipcode", "pk": 915}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95377"}, "model": "locality.zipcode", "pk": 916}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "08690"}, "model": "locality.zipcode", "pk": 917}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94521"}, "model": "locality.zipcode", "pk": 918}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19085"}, "model": "locality.zipcode", "pk": 919}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94537"}, "model": "locality.zipcode", "pk": 920}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94028"}, "model": "locality.zipcode", "pk": 921}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60067"}, "model": "locality.zipcode", "pk": 922}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33469"}, "model": "locality.zipcode", "pk": 923}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94133"}, "model": "locality.zipcode", "pk": 924}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "08003"}, "model": "locality.zipcode", "pk": 925}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94306"}, "model": "locality.zipcode", "pk": 926}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33431"}, "model": "locality.zipcode", "pk": 927}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94579"}, "model": "locality.zipcode", "pk": 928}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94037"}, "model": "locality.zipcode", "pk": 929}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80211"}, "model": "locality.zipcode", "pk": 930}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94539"}, "model": "locality.zipcode", "pk": 931}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94553"}, "model": "locality.zipcode", "pk": 932}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95061"}, "model": "locality.zipcode", "pk": 933}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95409"}, "model": "locality.zipcode", "pk": 934}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95660"}, "model": "locality.zipcode", "pk": 935}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94957"}, "model": "locality.zipcode", "pk": 936}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32801"}, "model": "locality.zipcode", "pk": 937}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "18510"}, "model": "locality.zipcode", "pk": 938}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30019"}, "model": "locality.zipcode", "pk": 939}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80127"}, "model": "locality.zipcode", "pk": 940}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32766"}, "model": "locality.zipcode", "pk": 941}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95356"}, "model": "locality.zipcode", "pk": 942}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95119"}, "model": "locality.zipcode", "pk": 943}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94019"}, "model": "locality.zipcode", "pk": 944}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98642"}, "model": "locality.zipcode", "pk": 945}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94661"}, "model": "locality.zipcode", "pk": 946}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95128"}, "model": "locality.zipcode", "pk": 947}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95123"}, "model": "locality.zipcode", "pk": 948}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95111"}, "model": "locality.zipcode", "pk": 949}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95136"}, "model": "locality.zipcode", "pk": 950}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95062"}, "model": "locality.zipcode", "pk": 951}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93035"}, "model": "locality.zipcode", "pk": 952}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94504"}, "model": "locality.zipcode", "pk": 953}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94535"}, "model": "locality.zipcode", "pk": 954}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95006"}, "model": "locality.zipcode", "pk": 955}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95616"}, "model": "locality.zipcode", "pk": 956}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95959"}, "model": "locality.zipcode", "pk": 957}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20912"}, "model": "locality.zipcode", "pk": 958}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32765"}, "model": "locality.zipcode", "pk": 959}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90290"}, "model": "locality.zipcode", "pk": 960}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11740"}, "model": "locality.zipcode", "pk": 961}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97223"}, "model": "locality.zipcode", "pk": 962}, {"fields": {"county": null, "city": null, "state": 284, "name": null, "short_name": "37205"}, "model": "locality.zipcode", "pk": 963}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11215"}, "model": "locality.zipcode", "pk": 964}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "12472"}, "model": "locality.zipcode", "pk": 965}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95304"}, "model": "locality.zipcode", "pk": 966}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21210"}, "model": "locality.zipcode", "pk": 967}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94590"}, "model": "locality.zipcode", "pk": 968}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "14850"}, "model": "locality.zipcode", "pk": 969}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93444"}, "model": "locality.zipcode", "pk": 970}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94172"}, "model": "locality.zipcode", "pk": 971}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11771"}, "model": "locality.zipcode", "pk": 972}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10011"}, "model": "locality.zipcode", "pk": 973}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93711"}, "model": "locality.zipcode", "pk": 974}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94960"}, "model": "locality.zipcode", "pk": 975}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97843"}, "model": "locality.zipcode", "pk": 976}, {"fields": {"county": null, "city": null, "state": 132, "name": null, "short_name": "70815"}, "model": "locality.zipcode", "pk": 977}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77901"}, "model": "locality.zipcode", "pk": 978}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95376"}, "model": "locality.zipcode", "pk": 979}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97211"}, "model": "locality.zipcode", "pk": 980}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94939"}, "model": "locality.zipcode", "pk": 981}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "16053"}, "model": "locality.zipcode", "pk": 982}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10026"}, "model": "locality.zipcode", "pk": 983}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19312"}, "model": "locality.zipcode", "pk": 984}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "15232"}, "model": "locality.zipcode", "pk": 985}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "16001"}, "model": "locality.zipcode", "pk": 986}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "48203"}, "model": "locality.zipcode", "pk": 987}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90403"}, "model": "locality.zipcode", "pk": 988}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60601"}, "model": "locality.zipcode", "pk": 989}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "18040"}, "model": "locality.zipcode", "pk": 990}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94533"}, "model": "locality.zipcode", "pk": 991}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77840"}, "model": "locality.zipcode", "pk": 992}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "17104"}, "model": "locality.zipcode", "pk": 993}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93722"}, "model": "locality.zipcode", "pk": 994}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22203"}, "model": "locality.zipcode", "pk": 995}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93923"}, "model": "locality.zipcode", "pk": 996}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95003"}, "model": "locality.zipcode", "pk": 997}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94620"}, "model": "locality.zipcode", "pk": 998}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94930"}, "model": "locality.zipcode", "pk": 999}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93535"}, "model": "locality.zipcode", "pk": 1000}, {"fields": {"county": null, "city": null, "state": 639, "name": null, "short_name": "87505"}, "model": "locality.zipcode", "pk": 1002}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02139"}, "model": "locality.zipcode", "pk": 1003}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "15228"}, "model": "locality.zipcode", "pk": 1004}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19355"}, "model": "locality.zipcode", "pk": 1005}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87501"}, "model": "locality.zipcode", "pk": 1006}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94305"}, "model": "locality.zipcode", "pk": 1007}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "15217"}, "model": "locality.zipcode", "pk": 1008}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22627"}, "model": "locality.zipcode", "pk": 1009}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94304"}, "model": "locality.zipcode", "pk": 1010}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22027"}, "model": "locality.zipcode", "pk": 1011}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78209"}, "model": "locality.zipcode", "pk": 1012}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80305"}, "model": "locality.zipcode", "pk": 1013}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94544"}, "model": "locality.zipcode", "pk": 1014}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95008"}, "model": "locality.zipcode", "pk": 1015}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02144"}, "model": "locality.zipcode", "pk": 1016}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19041"}, "model": "locality.zipcode", "pk": 1017}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02476"}, "model": "locality.zipcode", "pk": 1018}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "15222"}, "model": "locality.zipcode", "pk": 1019}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90250"}, "model": "locality.zipcode", "pk": 1020}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "16101"}, "model": "locality.zipcode", "pk": 1021}, {"fields": {"county": null, "city": null, "state": 547, "name": null, "short_name": "04021"}, "model": "locality.zipcode", "pk": 1022}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80027"}, "model": "locality.zipcode", "pk": 1023}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77904"}, "model": "locality.zipcode", "pk": 1024}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87540"}, "model": "locality.zipcode", "pk": 1025}, {"fields": {"county": null, "city": null, "state": 657, "name": null, "short_name": "52753"}, "model": "locality.zipcode", "pk": 1026}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19106"}, "model": "locality.zipcode", "pk": 1027}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21218"}, "model": "locality.zipcode", "pk": 1028}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98506"}, "model": "locality.zipcode", "pk": 1029}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77005"}, "model": "locality.zipcode", "pk": 1030}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95134"}, "model": "locality.zipcode", "pk": 1031}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "76210"}, "model": "locality.zipcode", "pk": 1032}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10014"}, "model": "locality.zipcode", "pk": 1033}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19060"}, "model": "locality.zipcode", "pk": 1034}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33418"}, "model": "locality.zipcode", "pk": 1035}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85226"}, "model": "locality.zipcode", "pk": 1036}, {"fields": {"county": null, "city": null, "state": 663, "name": null, "short_name": "57106"}, "model": "locality.zipcode", "pk": 1037}, {"fields": {"county": null, "city": null, "state": 381, "name": null, "short_name": "03801"}, "model": "locality.zipcode", "pk": 1038}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91387"}, "model": "locality.zipcode", "pk": 1039}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95132"}, "model": "locality.zipcode", "pk": 1040}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90058"}, "model": "locality.zipcode", "pk": 1041}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92887"}, "model": "locality.zipcode", "pk": 1042}, {"fields": {"county": null, "city": null, "state": 383, "name": null, "short_name": "41001"}, "model": "locality.zipcode", "pk": 1043}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94888"}, "model": "locality.zipcode", "pk": 1044}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92620"}, "model": "locality.zipcode", "pk": 1045}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "07626"}, "model": "locality.zipcode", "pk": 1046}, {"fields": {"county": null, "city": null, "state": 51, "name": null, "short_name": "20008"}, "model": "locality.zipcode", "pk": 1047}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90018"}, "model": "locality.zipcode", "pk": 1048}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34134"}, "model": "locality.zipcode", "pk": 1049}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10580"}, "model": "locality.zipcode", "pk": 1050}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80126"}, "model": "locality.zipcode", "pk": 1051}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21666"}, "model": "locality.zipcode", "pk": 1052}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30315"}, "model": "locality.zipcode", "pk": 1053}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10504"}, "model": "locality.zipcode", "pk": 1054}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97527"}, "model": "locality.zipcode", "pk": 1055}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90702"}, "model": "locality.zipcode", "pk": 1056}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90504"}, "model": "locality.zipcode", "pk": 1057}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32224"}, "model": "locality.zipcode", "pk": 1058}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94062"}, "model": "locality.zipcode", "pk": 1059}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91360"}, "model": "locality.zipcode", "pk": 1060}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94946"}, "model": "locality.zipcode", "pk": 1061}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33131"}, "model": "locality.zipcode", "pk": 1062}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "65127"}, "model": "locality.zipcode", "pk": 1063}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94937"}, "model": "locality.zipcode", "pk": 1064}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10024"}, "model": "locality.zipcode", "pk": 1065}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90401"}, "model": "locality.zipcode", "pk": 1066}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "BWI"}, "model": "locality.zipcode", "pk": 1067}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78701"}, "model": "locality.zipcode", "pk": 1068}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "48642"}, "model": "locality.zipcode", "pk": 1069}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92050"}, "model": "locality.zipcode", "pk": 1070}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "01966"}, "model": "locality.zipcode", "pk": 1071}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91708"}, "model": "locality.zipcode", "pk": 1072}, {"fields": {"county": null, "city": null, "state": 142, "name": null, "short_name": "43214"}, "model": "locality.zipcode", "pk": 1073}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92509"}, "model": "locality.zipcode", "pk": 1074}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95812"}, "model": "locality.zipcode", "pk": 1075}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92145"}, "model": "locality.zipcode", "pk": 1076}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91766"}, "model": "locality.zipcode", "pk": 1077}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90808"}, "model": "locality.zipcode", "pk": 1078}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91364"}, "model": "locality.zipcode", "pk": 1079}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92866"}, "model": "locality.zipcode", "pk": 1080}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90605"}, "model": "locality.zipcode", "pk": 1081}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92604"}, "model": "locality.zipcode", "pk": 1082}, {"fields": {"county": null, "city": null, "state": 373, "name": null, "short_name": "39564"}, "model": "locality.zipcode", "pk": 1083}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80113"}, "model": "locality.zipcode", "pk": 1084}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92182"}, "model": "locality.zipcode", "pk": 1085}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80239"}, "model": "locality.zipcode", "pk": 1086}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92691"}, "model": "locality.zipcode", "pk": 1087}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92161"}, "model": "locality.zipcode", "pk": 1088}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "81435"}, "model": "locality.zipcode", "pk": 1089}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85249"}, "model": "locality.zipcode", "pk": 1090}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94027"}, "model": "locality.zipcode", "pk": 1091}, {"fields": {"county": null, "city": null, "state": 343, "name": null, "short_name": "54481"}, "model": "locality.zipcode", "pk": 1092}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "64112"}, "model": "locality.zipcode", "pk": 1093}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "86301"}, "model": "locality.zipcode", "pk": 1094}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89103"}, "model": "locality.zipcode", "pk": 1095}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75225"}, "model": "locality.zipcode", "pk": 1096}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33444"}, "model": "locality.zipcode", "pk": 1097}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92004"}, "model": "locality.zipcode", "pk": 1098}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "76133"}, "model": "locality.zipcode", "pk": 1099}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23320"}, "model": "locality.zipcode", "pk": 1100}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23451"}, "model": "locality.zipcode", "pk": 1101}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10105"}, "model": "locality.zipcode", "pk": 1102}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87505"}, "model": "locality.zipcode", "pk": 1103}, {"fields": {"county": null, "city": null, "state": 305, "name": null, "short_name": "73116"}, "model": "locality.zipcode", "pk": 1104}, {"fields": {"county": null, "city": null, "state": 305, "name": null, "short_name": "74114"}, "model": "locality.zipcode", "pk": 1105}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33498"}, "model": "locality.zipcode", "pk": 1106}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "86018"}, "model": "locality.zipcode", "pk": 1107}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30127"}, "model": "locality.zipcode", "pk": 1108}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06410"}, "model": "locality.zipcode", "pk": 1109}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19002"}, "model": "locality.zipcode", "pk": 1110}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93010"}, "model": "locality.zipcode", "pk": 1111}, {"fields": {"county": null, "city": null, "state": 663, "name": null, "short_name": "57270"}, "model": "locality.zipcode", "pk": 1112}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "75071"}, "model": "locality.zipcode", "pk": 1113}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89005"}, "model": "locality.zipcode", "pk": 1114}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91320"}, "model": "locality.zipcode", "pk": 1115}, {"fields": {"county": null, "city": null, "state": 706, "name": null, "short_name": "99575"}, "model": "locality.zipcode", "pk": 1116}, {"fields": {"county": null, "city": null, "state": 706, "name": null, "short_name": "99515"}, "model": "locality.zipcode", "pk": 1117}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85019"}, "model": "locality.zipcode", "pk": 1118}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91361"}, "model": "locality.zipcode", "pk": 1119}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91789"}, "model": "locality.zipcode", "pk": 1120}, {"fields": {"county": null, "city": null, "state": 319, "name": null, "short_name": "97212"}, "model": "locality.zipcode", "pk": 1121}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80301"}, "model": "locality.zipcode", "pk": 1122}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92101"}, "model": "locality.zipcode", "pk": 1123}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92172"}, "model": "locality.zipcode", "pk": 1124}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92191"}, "model": "locality.zipcode", "pk": 1125}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92037"}, "model": "locality.zipcode", "pk": 1126}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10111"}, "model": "locality.zipcode", "pk": 1127}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92244"}, "model": "locality.zipcode", "pk": 1128}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92115"}, "model": "locality.zipcode", "pk": 1129}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90650"}, "model": "locality.zipcode", "pk": 1130}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92119"}, "model": "locality.zipcode", "pk": 1131}, {"fields": {"county": null, "city": null, "state": 30, "name": null, "short_name": "92129"}, "model": "locality.zipcode", "pk": 1132}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60538"}, "model": "locality.zipcode", "pk": 1133}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33139"}, "model": "locality.zipcode", "pk": 1134}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32835"}, "model": "locality.zipcode", "pk": 1135}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89011"}, "model": "locality.zipcode", "pk": 1136}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33617"}, "model": "locality.zipcode", "pk": 1137}, {"fields": {"county": null, "city": null, "state": 494, "name": null, "short_name": "59808"}, "model": "locality.zipcode", "pk": 1138}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34786"}, "model": "locality.zipcode", "pk": 1139}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60637"}, "model": "locality.zipcode", "pk": 1140}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "28704"}, "model": "locality.zipcode", "pk": 1141}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93704"}, "model": "locality.zipcode", "pk": 1142}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "13090"}, "model": "locality.zipcode", "pk": 1143}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78284"}, "model": "locality.zipcode", "pk": 1144}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80903"}, "model": "locality.zipcode", "pk": 1145}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98109"}, "model": "locality.zipcode", "pk": 1146}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77079"}, "model": "locality.zipcode", "pk": 1147}, {"fields": {"county": null, "city": null, "state": 99, "name": null, "short_name": "83864"}, "model": "locality.zipcode", "pk": 1148}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93105"}, "model": "locality.zipcode", "pk": 1149}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02072"}, "model": "locality.zipcode", "pk": 1150}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92016"}, "model": "locality.zipcode", "pk": 1151}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92232"}, "model": "locality.zipcode", "pk": 1152}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60515"}, "model": "locality.zipcode", "pk": 1153}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93004"}, "model": "locality.zipcode", "pk": 1154}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85050"}, "model": "locality.zipcode", "pk": 1155}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90603"}, "model": "locality.zipcode", "pk": 1156}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94051"}, "model": "locality.zipcode", "pk": 1157}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90046"}, "model": "locality.zipcode", "pk": 1158}, {"fields": {"county": null, "city": null, "state": 159, "name": null, "short_name": "46033"}, "model": "locality.zipcode", "pk": 1159}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60647"}, "model": "locality.zipcode", "pk": 1160}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90026"}, "model": "locality.zipcode", "pk": 1161}, {"fields": {"county": null, "city": null, "state": 657, "name": null, "short_name": "50309"}, "model": "locality.zipcode", "pk": 1162}, {"fields": {"county": null, "city": null, "state": 95, "name": null, "short_name": "87112"}, "model": "locality.zipcode", "pk": 1163}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10038"}, "model": "locality.zipcode", "pk": 1164}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90755"}, "model": "locality.zipcode", "pk": 1165}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "7104"}, "model": "locality.zipcode", "pk": 1166}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78223"}, "model": "locality.zipcode", "pk": 1167}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "28205"}, "model": "locality.zipcode", "pk": 1168}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33402"}, "model": "locality.zipcode", "pk": 1169}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "21042"}, "model": "locality.zipcode", "pk": 1170}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92074"}, "model": "locality.zipcode", "pk": 1171}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91919"}, "model": "locality.zipcode", "pk": 1172}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93644"}, "model": "locality.zipcode", "pk": 1173}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90745"}, "model": "locality.zipcode", "pk": 1174}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95242"}, "model": "locality.zipcode", "pk": 1175}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98801"}, "model": "locality.zipcode", "pk": 1176}, {"fields": {"county": null, "city": null, "state": 12, "name": null, "short_name": "48111"}, "model": "locality.zipcode", "pk": 1177}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90404"}, "model": "locality.zipcode", "pk": 1178}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "01821"}, "model": "locality.zipcode", "pk": 1179}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "02556"}, "model": "locality.zipcode", "pk": 1180}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "20191"}, "model": "locality.zipcode", "pk": 1181}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10463"}, "model": "locality.zipcode", "pk": 1182}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "32120"}, "model": "locality.zipcode", "pk": 1183}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "02037"}, "model": "locality.zipcode", "pk": 1184}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91208"}, "model": "locality.zipcode", "pk": 1185}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92392"}, "model": "locality.zipcode", "pk": 1186}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92142"}, "model": "locality.zipcode", "pk": 1187}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92079"}, "model": "locality.zipcode", "pk": 1188}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92165"}, "model": "locality.zipcode", "pk": 1189}, {"fields": {"county": null, "city": null, "state": 432, "name": null, "short_name": "19850"}, "model": "locality.zipcode", "pk": 1190}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91401"}, "model": "locality.zipcode", "pk": 1191}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92264"}, "model": "locality.zipcode", "pk": 1192}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91007"}, "model": "locality.zipcode", "pk": 1193}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95827"}, "model": "locality.zipcode", "pk": 1194}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60015"}, "model": "locality.zipcode", "pk": 1195}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "78720"}, "model": "locality.zipcode", "pk": 1196}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92593"}, "model": "locality.zipcode", "pk": 1197}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90701"}, "model": "locality.zipcode", "pk": 1198}, {"fields": {"county": null, "city": null, "state": 639, "name": null, "short_name": "35674"}, "model": "locality.zipcode", "pk": 1199}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90831"}, "model": "locality.zipcode", "pk": 1200}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11362"}, "model": "locality.zipcode", "pk": 1201}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77581"}, "model": "locality.zipcode", "pk": 1202}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "19067"}, "model": "locality.zipcode", "pk": 1203}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "11355"}, "model": "locality.zipcode", "pk": 1204}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77055"}, "model": "locality.zipcode", "pk": 1205}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93003"}, "model": "locality.zipcode", "pk": 1206}, {"fields": {"county": null, "city": null, "state": 102, "name": null, "short_name": "98073"}, "model": "locality.zipcode", "pk": 1207}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91301"}, "model": "locality.zipcode", "pk": 1208}, {"fields": {"county": null, "city": null, "state": 58, "name": null, "short_name": "01752"}, "model": "locality.zipcode", "pk": 1209}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "85364"}, "model": "locality.zipcode", "pk": 1210}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92802"}, "model": "locality.zipcode", "pk": 1211}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89402"}, "model": "locality.zipcode", "pk": 1212}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92879"}, "model": "locality.zipcode", "pk": 1213}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91354"}, "model": "locality.zipcode", "pk": 1214}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22079"}, "model": "locality.zipcode", "pk": 1215}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33487"}, "model": "locality.zipcode", "pk": 1216}, {"fields": {"county": null, "city": null, "state": 284, "name": null, "short_name": "37069"}, "model": "locality.zipcode", "pk": 1217}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80112"}, "model": "locality.zipcode", "pk": 1218}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22182"}, "model": "locality.zipcode", "pk": 1219}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "27519"}, "model": "locality.zipcode", "pk": 1220}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "22209"}, "model": "locality.zipcode", "pk": 1221}, {"fields": {"county": null, "city": null, "state": 99, "name": null, "short_name": "83706"}, "model": "locality.zipcode", "pk": 1222}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92270"}, "model": "locality.zipcode", "pk": 1223}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90032"}, "model": "locality.zipcode", "pk": 1224}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33701"}, "model": "locality.zipcode", "pk": 1225}, {"fields": {"county": null, "city": null, "state": 159, "name": null, "short_name": "46539"}, "model": "locality.zipcode", "pk": 1226}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89109"}, "model": "locality.zipcode", "pk": 1227}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90038"}, "model": "locality.zipcode", "pk": 1228}, {"fields": {"county": null, "city": null, "state": 61, "name": null, "short_name": "17110"}, "model": "locality.zipcode", "pk": 1229}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33496"}, "model": "locality.zipcode", "pk": 1230}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92196"}, "model": "locality.zipcode", "pk": 1231}, {"fields": {"county": null, "city": null, "state": 41, "name": null, "short_name": "20817"}, "model": "locality.zipcode", "pk": 1232}, {"fields": {"county": null, "city": null, "state": 231, "name": null, "short_name": "06001"}, "model": "locality.zipcode", "pk": 1233}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95503"}, "model": "locality.zipcode", "pk": 1234}, {"fields": {"county": null, "city": null, "state": 4, "name": null, "short_name": "86001"}, "model": "locality.zipcode", "pk": 1235}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92169"}, "model": "locality.zipcode", "pk": 1236}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "07006"}, "model": "locality.zipcode", "pk": 1237}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "94042"}, "model": "locality.zipcode", "pk": 1238}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80023"}, "model": "locality.zipcode", "pk": 1239}, {"fields": {"county": null, "city": null, "state": 162, "name": null, "short_name": "30319"}, "model": "locality.zipcode", "pk": 1240}, {"fields": {"county": null, "city": null, "state": 494, "name": null, "short_name": "59870"}, "model": "locality.zipcode", "pk": 1241}, {"fields": {"county": null, "city": null, "state": 73, "name": null, "short_name": "89148"}, "model": "locality.zipcode", "pk": 1242}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92262"}, "model": "locality.zipcode", "pk": 1243}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91608"}, "model": "locality.zipcode", "pk": 1244}, {"fields": {"county": null, "city": null, "state": 639, "name": null, "short_name": "35242"}, "model": "locality.zipcode", "pk": 1245}, {"fields": {"county": null, "city": null, "state": 53, "name": null, "short_name": "28630"}, "model": "locality.zipcode", "pk": 1246}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "91326"}, "model": "locality.zipcode", "pk": 1247}, {"fields": {"county": null, "city": null, "state": 639, "name": null, "short_name": "35209"}, "model": "locality.zipcode", "pk": 1248}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33432"}, "model": "locality.zipcode", "pk": 1249}, {"fields": {"county": null, "city": null, "state": 436, "name": null, "short_name": "07079"}, "model": "locality.zipcode", "pk": 1250}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "90274"}, "model": "locality.zipcode", "pk": 1251}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "95746"}, "model": "locality.zipcode", "pk": 1252}, {"fields": {"county": null, "city": null, "state": 132, "name": null, "short_name": "70117"}, "model": "locality.zipcode", "pk": 1253}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "34105"}, "model": "locality.zipcode", "pk": 1254}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "10002"}, "model": "locality.zipcode", "pk": 1255}, {"fields": {"county": null, "city": null, "state": 68, "name": null, "short_name": "23510"}, "model": "locality.zipcode", "pk": 1256}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "32937"}, "model": "locality.zipcode", "pk": 1257}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "13066"}, "model": "locality.zipcode", "pk": 1258}, {"fields": {"county": null, "city": null, "state": 87, "name": null, "short_name": "33061"}, "model": "locality.zipcode", "pk": 1259}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "13088"}, "model": "locality.zipcode", "pk": 1260}, {"fields": {"county": null, "city": null, "state": 18, "name": null, "short_name": "60119"}, "model": "locality.zipcode", "pk": 1261}, {"fields": {"county": null, "city": null, "state": 76, "name": null, "short_name": "13088"}, "model": "locality.zipcode", "pk": 1262}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92342"}, "model": "locality.zipcode", "pk": 1263}, {"fields": {"county": null, "city": null, "state": 79, "name": null, "short_name": "77487"}, "model": "locality.zipcode", "pk": 1264}, {"fields": {"county": null, "city": null, "state": 328, "name": null, "short_name": "84103"}, "model": "locality.zipcode", "pk": 1265}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80631"}, "model": "locality.zipcode", "pk": 1266}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92150"}, "model": "locality.zipcode", "pk": 1267}, {"fields": {"county": null, "city": null, "state": 66, "name": null, "short_name": "63101"}, "model": "locality.zipcode", "pk": 1268}, {"fields": {"county": null, "city": null, "state": 10, "name": null, "short_name": "80122"}, "model": "locality.zipcode", "pk": 1269}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92133"}, "model": "locality.zipcode", "pk": 1270}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "93744"}, "model": "locality.zipcode", "pk": 1271}, {"fields": {"county": null, "city": null, "state": 1, "name": null, "short_name": "92423"}, "model": "locality.zipcode", "pk": 1272}]
+[
+    {
+        "fields": {
+            "name": "California",
+            "short_name": "CA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "name": "San Diego",
+            "short_name": "CSD",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "name": "El Cajon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "AZ",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "name": "Phoenix",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "name": "La Jolla",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 6
+    },
+    {
+        "fields": {
+            "name": "Brea",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 7
+    },
+    {
+        "fields": {
+            "name": "Solana Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 8
+    },
+    {
+        "fields": {
+            "name": "San Francisco",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 9
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "CO",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 10
+    },
+    {
+        "fields": {
+            "name": "Greenwood Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 11
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MI",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 12
+    },
+    {
+        "fields": {
+            "name": "Mason",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 13
+    },
+    {
+        "fields": {
+            "name": "Sacramento",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 14
+    },
+    {
+        "fields": {
+            "name": "Los Angeles",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 15
+    },
+    {
+        "fields": {
+            "name": "Lemon Grove",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 16
+    },
+    {
+        "fields": {
+            "name": "La Mesa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 17
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "IL",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 18
+    },
+    {
+        "fields": {
+            "name": "Chicago",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 19
+    },
+    {
+        "fields": {
+            "name": "Encinitas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 20
+    },
+    {
+        "fields": {
+            "name": "San Ramon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 21
+    },
+    {
+        "fields": {
+            "name": "Escondido",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 22
+    },
+    {
+        "fields": {
+            "name": "Carlsbad",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 23
+    },
+    {
+        "fields": {
+            "name": "Rancho Santa Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 24
+    },
+    {
+        "fields": {
+            "name": "Riverside",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 25
+    },
+    {
+        "fields": {
+            "name": "Poway",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 26
+    },
+    {
+        "fields": {
+            "name": "Orange",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 27
+    },
+    {
+        "fields": {
+            "name": "Temecula",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 28
+    },
+    {
+        "fields": {
+            "name": "Jamul",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 29
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "Unknown-State",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 30
+    },
+    {
+        "fields": {
+            "name": "Unknown-City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 31
+    },
+    {
+        "fields": {
+            "name": "Coronado",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 32
+    },
+    {
+        "fields": {
+            "name": "Del Mar",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 33
+    },
+    {
+        "fields": {
+            "name": "San Marcos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 34
+    },
+    {
+        "fields": {
+            "name": "Spring Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 35
+    },
+    {
+        "fields": {
+            "name": "Vista",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 36
+    },
+    {
+        "fields": {
+            "name": "South San Francisco",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 37
+    },
+    {
+        "fields": {
+            "name": "Alamo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 38
+    },
+    {
+        "fields": {
+            "name": "Alpine",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 39
+    },
+    {
+        "fields": {
+            "name": "Colorado Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 40
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MD",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 41
+    },
+    {
+        "fields": {
+            "name": "Bethesda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 42
+    },
+    {
+        "fields": {
+            "name": "Murrieta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 43
+    },
+    {
+        "fields": {
+            "name": "Bonita",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 44
+    },
+    {
+        "fields": {
+            "name": "Irvine",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 45
+    },
+    {
+        "fields": {
+            "name": "Lakeside",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 46
+    },
+    {
+        "fields": {
+            "name": "Huntington Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 47
+    },
+    {
+        "fields": {
+            "name": "Wildomar",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 48
+    },
+    {
+        "fields": {
+            "name": "Newport Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 49
+    },
+    {
+        "fields": {
+            "name": "Marina Del Rey",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 50
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "DC",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 51
+    },
+    {
+        "fields": {
+            "name": "Washington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 52
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NC",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 53
+    },
+    {
+        "fields": {
+            "name": "Charlotte",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 54
+    },
+    {
+        "fields": {
+            "name": "Cardiff By The Sea",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 55
+    },
+    {
+        "fields": {
+            "name": "Aspen",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 56
+    },
+    {
+        "fields": {
+            "name": "Ladra Ranch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 57
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 58
+    },
+    {
+        "fields": {
+            "name": "Boston",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 59
+    },
+    {
+        "fields": {
+            "name": "Cupertino",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 60
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "PA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 61
+    },
+    {
+        "fields": {
+            "name": "Johnstown",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 62
+    },
+    {
+        "fields": {
+            "name": "Valley Center",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 63
+    },
+    {
+        "fields": {
+            "name": "Ramona",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 64
+    },
+    {
+        "fields": {
+            "name": "Cottonwood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 65
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MO",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 66
+    },
+    {
+        "fields": {
+            "name": "St. Louis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 67
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "VA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 68
+    },
+    {
+        "fields": {
+            "name": "Williamsburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 69
+    },
+    {
+        "fields": {
+            "name": "Diamond Bar",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 70
+    },
+    {
+        "fields": {
+            "name": "Oceanside",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 71
+    },
+    {
+        "fields": {
+            "name": "Chula Vista",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 72
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NV",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 73
+    },
+    {
+        "fields": {
+            "name": "Las Vegas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 74
+    },
+    {
+        "fields": {
+            "name": "Beverly Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 75
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NY",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 76
+    },
+    {
+        "fields": {
+            "name": "New York",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 77
+    },
+    {
+        "fields": {
+            "name": "Pasadena",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 78
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "TX",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 79
+    },
+    {
+        "fields": {
+            "name": "Driftwood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 80
+    },
+    {
+        "fields": {
+            "name": "Santee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 81
+    },
+    {
+        "fields": {
+            "name": "Yorba Linda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 82
+    },
+    {
+        "fields": {
+            "name": "Laguna Niguel",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 83
+    },
+    {
+        "fields": {
+            "name": "Tustin",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 84
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "WY",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 85
+    },
+    {
+        "fields": {
+            "name": "Cody",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 86
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "FL",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 87
+    },
+    {
+        "fields": {
+            "name": "Merritt Island",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 88
+    },
+    {
+        "fields": {
+            "name": "El Dorado Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 89
+    },
+    {
+        "fields": {
+            "name": "Chesapeake",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 90
+    },
+    {
+        "fields": {
+            "name": "Mountain Center",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 91
+    },
+    {
+        "fields": {
+            "name": "Glendale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 92
+    },
+    {
+        "fields": {
+            "name": "San Clemente",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 93
+    },
+    {
+        "fields": {
+            "name": "Virginia Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 94
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NM",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 95
+    },
+    {
+        "fields": {
+            "name": "Albuquerque",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 96
+    },
+    {
+        "fields": {
+            "name": "Indio",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 97
+    },
+    {
+        "fields": {
+            "name": "South Pasadena",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 98
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "ID",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 99
+    },
+    {
+        "fields": {
+            "name": "Boise",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 100
+    },
+    {
+        "fields": {
+            "name": "Big Bear Lake",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 101
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "WA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 102
+    },
+    {
+        "fields": {
+            "name": "Tacoma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 103
+    },
+    {
+        "fields": {
+            "name": "National City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 104
+    },
+    {
+        "fields": {
+            "name": "Anaheim",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 105
+    },
+    {
+        "fields": {
+            "name": "Oxnard",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 106
+    },
+    {
+        "fields": {
+            "name": "Boulder",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 107
+    },
+    {
+        "fields": {
+            "name": "Santa Maria",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 108
+    },
+    {
+        "fields": {
+            "name": "Imperial Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 109
+    },
+    {
+        "fields": {
+            "name": "Newport Coast",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 110
+    },
+    {
+        "fields": {
+            "name": "Vienna",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 111
+    },
+    {
+        "fields": {
+            "name": "Las Cruces",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 112
+    },
+    {
+        "fields": {
+            "name": "Paradise Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 113
+    },
+    {
+        "fields": {
+            "name": "La Habra",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 114
+    },
+    {
+        "fields": {
+            "name": "La Mirada",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 115
+    },
+    {
+        "fields": {
+            "name": "Stafford",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 116
+    },
+    {
+        "fields": {
+            "name": "Oakland",
+            "short_name": "COAK",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 117
+    },
+    {
+        "fields": {
+            "name": "Harrisburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 118
+    },
+    {
+        "fields": {
+            "name": "Paramount",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 119
+    },
+    {
+        "fields": {
+            "name": "San Mateo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 120
+    },
+    {
+        "fields": {
+            "name": "Tampa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 121
+    },
+    {
+        "fields": {
+            "name": "Whittier",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 122
+    },
+    {
+        "fields": {
+            "name": "Davis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 123
+    },
+    {
+        "fields": {
+            "name": "Berkeley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 124
+    },
+    {
+        "fields": {
+            "name": "Redwood City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 125
+    },
+    {
+        "fields": {
+            "name": "Hermosa Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 126
+    },
+    {
+        "fields": {
+            "name": "Montebello",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 127
+    },
+    {
+        "fields": {
+            "name": "Port Saint Lucie",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 128
+    },
+    {
+        "fields": {
+            "name": "Studio City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 129
+    },
+    {
+        "fields": {
+            "name": "Miami Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 130
+    },
+    {
+        "fields": {
+            "name": "Goleta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 131
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "LA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 132
+    },
+    {
+        "fields": {
+            "name": "New Orleans",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 133
+    },
+    {
+        "fields": {
+            "name": "Santa Ana",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 134
+    },
+    {
+        "fields": {
+            "name": "Lafayette",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 135
+    },
+    {
+        "fields": {
+            "name": "Rock Island",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 136
+    },
+    {
+        "fields": {
+            "name": "Alhambra",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 137
+    },
+    {
+        "fields": {
+            "name": "Rockville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 138
+    },
+    {
+        "fields": {
+            "name": "Hayward",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 139
+    },
+    {
+        "fields": {
+            "name": "Elk Grove",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 140
+    },
+    {
+        "fields": {
+            "name": "Fullerton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 141
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "OH",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 142
+    },
+    {
+        "fields": {
+            "name": "Beachwood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 143
+    },
+    {
+        "fields": {
+            "name": "Lakewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 144
+    },
+    {
+        "fields": {
+            "name": "Belvedere Tiburon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 145
+    },
+    {
+        "fields": {
+            "name": "Mountain View",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 146
+    },
+    {
+        "fields": {
+            "name": "Menlo Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 147
+    },
+    {
+        "fields": {
+            "name": "Laguna Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 148
+    },
+    {
+        "fields": {
+            "name": "West Sacramento",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 149
+    },
+    {
+        "fields": {
+            "name": "El Segundo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 150
+    },
+    {
+        "fields": {
+            "name": "Buena Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 151
+    },
+    {
+        "fields": {
+            "name": "Annapolis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 152
+    },
+    {
+        "fields": {
+            "name": "El Monte",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 153
+    },
+    {
+        "fields": {
+            "name": "North Las Vegas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 154
+    },
+    {
+        "fields": {
+            "name": "Corona",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 155
+    },
+    {
+        "fields": {
+            "name": "Long Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 156
+    },
+    {
+        "fields": {
+            "name": "Cerritos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 157
+    },
+    {
+        "fields": {
+            "name": "Vacaville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 158
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "IN",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 159
+    },
+    {
+        "fields": {
+            "name": "Carmel",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 160
+    },
+    {
+        "fields": {
+            "name": "Lombard",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 161
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "GA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 162
+    },
+    {
+        "fields": {
+            "name": "Atlanta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 163
+    },
+    {
+        "fields": {
+            "name": "Trabuco Canyon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 164
+    },
+    {
+        "fields": {
+            "name": "Roswell",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 165
+    },
+    {
+        "fields": {
+            "name": "Norfolk",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 166
+    },
+    {
+        "fields": {
+            "name": "Richmond",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 167
+    },
+    {
+        "fields": {
+            "name": "Seattle",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 168
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "XX",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 169
+    },
+    {
+        "fields": {
+            "name": "Singapore",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 170
+    },
+    {
+        "fields": {
+            "name": "Solano Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 171
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "HI",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 172
+    },
+    {
+        "fields": {
+            "name": "Aiea",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 173
+    },
+    {
+        "fields": {
+            "name": "Arlington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 174
+    },
+    {
+        "fields": {
+            "name": "Newcastle",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 175
+    },
+    {
+        "fields": {
+            "name": "Yucca Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 176
+    },
+    {
+        "fields": {
+            "name": "Barrington Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 177
+    },
+    {
+        "fields": {
+            "name": "San Gabriel",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 178
+    },
+    {
+        "fields": {
+            "name": "Fallbrook",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 179
+    },
+    {
+        "fields": {
+            "name": "Herndon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 180
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NE",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 181
+    },
+    {
+        "fields": {
+            "name": "Omaha",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 182
+    },
+    {
+        "fields": {
+            "name": "Winter Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 183
+    },
+    {
+        "fields": {
+            "name": "Orlando",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 184
+    },
+    {
+        "fields": {
+            "name": "Kissimmee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 185
+    },
+    {
+        "fields": {
+            "name": "Dallas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 186
+    },
+    {
+        "fields": {
+            "name": "Torrance",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 187
+    },
+    {
+        "fields": {
+            "name": "Englewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 188
+    },
+    {
+        "fields": {
+            "name": "Irving",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 189
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "SC",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 190
+    },
+    {
+        "fields": {
+            "name": "Hartsville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 191
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "AR",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 192
+    },
+    {
+        "fields": {
+            "name": "Bentonville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 193
+    },
+    {
+        "fields": {
+            "name": "Ontario",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 194
+    },
+    {
+        "fields": {
+            "name": "Palomar Mountain",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 195
+    },
+    {
+        "fields": {
+            "name": "San Juan Capistrano",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 196
+    },
+    {
+        "fields": {
+            "name": "Winchester",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 197
+    },
+    {
+        "fields": {
+            "name": "Dove Canyon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 198
+    },
+    {
+        "fields": {
+            "name": "Clayton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 199
+    },
+    {
+        "fields": {
+            "name": "Palo Alto",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 200
+    },
+    {
+        "fields": {
+            "name": "Las Vegas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 201
+    },
+    {
+        "fields": {
+            "name": "Dana Point",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 202
+    },
+    {
+        "fields": {
+            "name": "Burbank",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 203
+    },
+    {
+        "fields": {
+            "name": "San Leandro",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 204
+    },
+    {
+        "fields": {
+            "name": "Sherman Oaks",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 205
+    },
+    {
+        "fields": {
+            "name": "Willits",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 206
+    },
+    {
+        "fields": {
+            "name": "San Ysidro",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 207
+    },
+    {
+        "fields": {
+            "name": "West Hollywood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 208
+    },
+    {
+        "fields": {
+            "name": "Hollywood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 209
+    },
+    {
+        "fields": {
+            "name": "El Centro",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 210
+    },
+    {
+        "fields": {
+            "name": "Scottsdale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 211
+    },
+    {
+        "fields": {
+            "name": "San Antonio",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 212
+    },
+    {
+        "fields": {
+            "name": "Van Nuys",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 213
+    },
+    {
+        "fields": {
+            "name": "Palm Desert",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 214
+    },
+    {
+        "fields": {
+            "name": "Fort Lauderdale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 215
+    },
+    {
+        "fields": {
+            "name": "Sloughhouse",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 216
+    },
+    {
+        "fields": {
+            "name": "Holtville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 217
+    },
+    {
+        "fields": {
+            "name": "Goshen",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 218
+    },
+    {
+        "fields": {
+            "name": "Valley Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 219
+    },
+    {
+        "fields": {
+            "name": "Brookline",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 220
+    },
+    {
+        "fields": {
+            "name": "Reseda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 221
+    },
+    {
+        "fields": {
+            "name": "Cathedral City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 222
+    },
+    {
+        "fields": {
+            "name": "Alameda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 223
+    },
+    {
+        "fields": {
+            "name": "Santa Barbara",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 224
+    },
+    {
+        "fields": {
+            "name": "San Jose",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 225
+    },
+    {
+        "fields": {
+            "name": "Mercer Island",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 226
+    },
+    {
+        "fields": {
+            "name": "El Sauzal",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 227
+    },
+    {
+        "fields": {
+            "name": "Belmont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 228
+    },
+    {
+        "fields": {
+            "name": "Newport News",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 229
+    },
+    {
+        "fields": {
+            "name": "Lucerne Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 230
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "CT",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 231
+    },
+    {
+        "fields": {
+            "name": "New Cannan",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 232
+    },
+    {
+        "fields": {
+            "name": "Sabn Diego",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 233
+    },
+    {
+        "fields": {
+            "name": "Pacific Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 234
+    },
+    {
+        "fields": {
+            "name": "Guilford",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 235
+    },
+    {
+        "fields": {
+            "name": "Kansas City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 236
+    },
+    {
+        "fields": {
+            "name": "Brooklyn",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 237
+    },
+    {
+        "fields": {
+            "name": "Pacific Palisades",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 238
+    },
+    {
+        "fields": {
+            "name": "San Sdiego",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 239
+    },
+    {
+        "fields": {
+            "name": "Englewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 240
+    },
+    {
+        "fields": {
+            "name": "Pleasanton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 241
+    },
+    {
+        "fields": {
+            "name": "Venice",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 242
+    },
+    {
+        "fields": {
+            "name": "Grass Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 243
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "ZZ",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 244
+    },
+    {
+        "fields": {
+            "name": "Unknown-City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 245
+    },
+    {
+        "fields": {
+            "name": "Barrington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 246
+    },
+    {
+        "fields": {
+            "name": "San Marino",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 247
+    },
+    {
+        "fields": {
+            "name": "Little Rock",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 248
+    },
+    {
+        "fields": {
+            "name": "Sausalito",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 249
+    },
+    {
+        "fields": {
+            "name": "Honolulu",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 250
+    },
+    {
+        "fields": {
+            "name": "Claremont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 251
+    },
+    {
+        "fields": {
+            "name": "North Hollywood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 252
+    },
+    {
+        "fields": {
+            "name": "Rcho Santa Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 253
+    },
+    {
+        "fields": {
+            "name": "Roxbury",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 254
+    },
+    {
+        "fields": {
+            "name": "Campo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 255
+    },
+    {
+        "fields": {
+            "name": "La Quinta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 256
+    },
+    {
+        "fields": {
+            "name": "Culver City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 257
+    },
+    {
+        "fields": {
+            "name": "Ball Ground",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 258
+    },
+    {
+        "fields": {
+            "name": "Tempe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 259
+    },
+    {
+        "fields": {
+            "name": "Kildeer",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 260
+    },
+    {
+        "fields": {
+            "name": "Tiburon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 261
+    },
+    {
+        "fields": {
+            "name": "Corona Del Mar",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 262
+    },
+    {
+        "fields": {
+            "name": "Marietta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 263
+    },
+    {
+        "fields": {
+            "name": "Camarillo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 264
+    },
+    {
+        "fields": {
+            "name": "Calabasas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 265
+    },
+    {
+        "fields": {
+            "name": "Arcadia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 266
+    },
+    {
+        "fields": {
+            "name": "Hillsborough",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 267
+    },
+    {
+        "fields": {
+            "name": "Suwanee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 268
+    },
+    {
+        "fields": {
+            "name": "Eatonton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 269
+    },
+    {
+        "fields": {
+            "name": "Kahului",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 270
+    },
+    {
+        "fields": {
+            "name": "Ojai",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 271
+    },
+    {
+        "fields": {
+            "name": "Gardena",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 272
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MN",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 273
+    },
+    {
+        "fields": {
+            "name": "Columbia Heights",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 274
+    },
+    {
+        "fields": {
+            "name": "Yarmouth Port",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 275
+    },
+    {
+        "fields": {
+            "name": "Plantation",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 276
+    },
+    {
+        "fields": {
+            "name": "Coto De Caza",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 277
+    },
+    {
+        "fields": {
+            "name": "Rancho Cucamonga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 278
+    },
+    {
+        "fields": {
+            "name": "Incline Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 279
+    },
+    {
+        "fields": {
+            "name": "Trabuco Canyon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 280
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "WV",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 281
+    },
+    {
+        "fields": {
+            "name": "Charleston",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 282
+    },
+    {
+        "fields": {
+            "name": "Orinda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 283
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "TN",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 284
+    },
+    {
+        "fields": {
+            "name": "Franklin",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 285
+    },
+    {
+        "fields": {
+            "name": "El Cerrito",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 286
+    },
+    {
+        "fields": {
+            "name": "Alpharetta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 287
+    },
+    {
+        "fields": {
+            "name": "Malibu",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 288
+    },
+    {
+        "fields": {
+            "name": "Kailua",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 289
+    },
+    {
+        "fields": {
+            "name": "Descanso",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 290
+    },
+    {
+        "fields": {
+            "name": "Wilson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 291
+    },
+    {
+        "fields": {
+            "name": "Monument",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 292
+    },
+    {
+        "fields": {
+            "name": "Capistrano Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 293
+    },
+    {
+        "fields": {
+            "name": "Houston",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 294
+    },
+    {
+        "fields": {
+            "name": "San Rafael",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 295
+    },
+    {
+        "fields": {
+            "name": "Placentia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 296
+    },
+    {
+        "fields": {
+            "name": "Redondo Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 297
+    },
+    {
+        "fields": {
+            "name": "Denver",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 298
+    },
+    {
+        "fields": {
+            "name": "Richmond",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 299
+    },
+    {
+        "fields": {
+            "name": "Canyon Lake",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 300
+    },
+    {
+        "fields": {
+            "name": "Laguna Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 301
+    },
+    {
+        "fields": {
+            "name": "Bonsall",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 302
+    },
+    {
+        "fields": {
+            "name": "Springfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 303
+    },
+    {
+        "fields": {
+            "name": "Lake Forest",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 304
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "OK",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 305
+    },
+    {
+        "fields": {
+            "name": "Oklahoma City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 306
+    },
+    {
+        "fields": {
+            "name": "Silver Spring",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 307
+    },
+    {
+        "fields": {
+            "name": "Cedarhurst",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 308
+    },
+    {
+        "fields": {
+            "name": "Encino",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 309
+    },
+    {
+        "fields": {
+            "name": "Cambridge",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 310
+    },
+    {
+        "fields": {
+            "name": "Cypress",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 311
+    },
+    {
+        "fields": {
+            "name": "Bolingbrook",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 312
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "UK",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 313
+    },
+    {
+        "fields": {
+            "name": "London",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 314
+    },
+    {
+        "fields": {
+            "name": "Los Altos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 315
+    },
+    {
+        "fields": {
+            "name": "Quantico",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 316
+    },
+    {
+        "fields": {
+            "name": "Spartanburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 317
+    },
+    {
+        "fields": {
+            "name": "Crozet",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 318
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "OR",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 319
+    },
+    {
+        "fields": {
+            "name": "Portland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 320
+    },
+    {
+        "fields": {
+            "name": "Pico Rivera",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 321
+    },
+    {
+        "fields": {
+            "name": "Bloomington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 322
+    },
+    {
+        "fields": {
+            "name": "Pomona",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 323
+    },
+    {
+        "fields": {
+            "name": "Hanover",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 324
+    },
+    {
+        "fields": {
+            "name": "Aurora",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 325
+    },
+    {
+        "fields": {
+            "name": "Philadelphia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 326
+    },
+    {
+        "fields": {
+            "name": "Santa Fe Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 327
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "UT",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 328
+    },
+    {
+        "fields": {
+            "name": "Park City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 329
+    },
+    {
+        "fields": {
+            "name": "Schaumburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 330
+    },
+    {
+        "fields": {
+            "name": "Lake Forest",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 331
+    },
+    {
+        "fields": {
+            "name": "Aliso Viejo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 332
+    },
+    {
+        "fields": {
+            "name": "Fountain Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 333
+    },
+    {
+        "fields": {
+            "name": "Blue Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 334
+    },
+    {
+        "fields": {
+            "name": "Benicia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 335
+    },
+    {
+        "fields": {
+            "name": "La Palma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 336
+    },
+    {
+        "fields": {
+            "name": "Redlands",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 337
+    },
+    {
+        "fields": {
+            "name": "Waltham",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 338
+    },
+    {
+        "fields": {
+            "name": "Valencia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 339
+    },
+    {
+        "fields": {
+            "name": "Sonoma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 340
+    },
+    {
+        "fields": {
+            "name": "Perris",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 341
+    },
+    {
+        "fields": {
+            "name": "Jackson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 342
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "WI",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 343
+    },
+    {
+        "fields": {
+            "name": "Milwaukee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 344
+    },
+    {
+        "fields": {
+            "name": "Tarzana",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 345
+    },
+    {
+        "fields": {
+            "name": "Danville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 346
+    },
+    {
+        "fields": {
+            "name": "Oracle",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 347
+    },
+    {
+        "fields": {
+            "name": "Manhattan Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 348
+    },
+    {
+        "fields": {
+            "name": "Santa Monica",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 349
+    },
+    {
+        "fields": {
+            "name": "San Carlos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 350
+    },
+    {
+        "fields": {
+            "name": "San Pedro",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 351
+    },
+    {
+        "fields": {
+            "name": "Mill Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 352
+    },
+    {
+        "fields": {
+            "name": "Altadena",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 353
+    },
+    {
+        "fields": {
+            "name": "Mira Loma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 354
+    },
+    {
+        "fields": {
+            "name": "Menifee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 355
+    },
+    {
+        "fields": {
+            "name": "Redding",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 356
+    },
+    {
+        "fields": {
+            "name": "Costa Mesa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 357
+    },
+    {
+        "fields": {
+            "name": "Cardiff",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 358
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "AE",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 359
+    },
+    {
+        "fields": {
+            "name": "France",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 360
+    },
+    {
+        "fields": {
+            "name": "Napa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 361
+    },
+    {
+        "fields": {
+            "name": "Mission Viejo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 362
+    },
+    {
+        "fields": {
+            "name": "San Bernardino",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 363
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "KS",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 364
+    },
+    {
+        "fields": {
+            "name": "Lenexa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 365
+    },
+    {
+        "fields": {
+            "name": "La Canada Flintridge",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 366
+    },
+    {
+        "fields": {
+            "name": "Spokane",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 367
+    },
+    {
+        "fields": {
+            "name": "Seal Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 368
+    },
+    {
+        "fields": {
+            "name": "Henderson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 369
+    },
+    {
+        "fields": {
+            "name": "Rancho Santa Margarita",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 370
+    },
+    {
+        "fields": {
+            "name": "Leawood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 371
+    },
+    {
+        "fields": {
+            "name": "Millis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 372
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MS",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 373
+    },
+    {
+        "fields": {
+            "name": "Biloxi",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 374
+    },
+    {
+        "fields": {
+            "name": "Novato",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 375
+    },
+    {
+        "fields": {
+            "name": "Ladera Ranch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 376
+    },
+    {
+        "fields": {
+            "name": "Bellflower",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 377
+    },
+    {
+        "fields": {
+            "name": "Brighton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 378
+    },
+    {
+        "fields": {
+            "name": "Julian",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 379
+    },
+    {
+        "fields": {
+            "name": "Thompson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 380
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NH",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 381
+    },
+    {
+        "fields": {
+            "name": "Hopkinton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 382
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "KY",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 383
+    },
+    {
+        "fields": {
+            "name": "Lexington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 384
+    },
+    {
+        "fields": {
+            "name": "Granada Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 385
+    },
+    {
+        "fields": {
+            "name": "Sammamish",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 386
+    },
+    {
+        "fields": {
+            "name": "La Verne",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 387
+    },
+    {
+        "fields": {
+            "name": "Odenton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 388
+    },
+    {
+        "fields": {
+            "name": "Santa Paula",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 389
+    },
+    {
+        "fields": {
+            "name": "North Bay Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 390
+    },
+    {
+        "fields": {
+            "name": "Lakewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 391
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "ND",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 392
+    },
+    {
+        "fields": {
+            "name": "Minot Afb",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 393
+    },
+    {
+        "fields": {
+            "name": "Bend",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 394
+    },
+    {
+        "fields": {
+            "name": "Abilene",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 395
+    },
+    {
+        "fields": {
+            "name": "Mineral Wells",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 396
+    },
+    {
+        "fields": {
+            "name": "Lo Jolla",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 397
+    },
+    {
+        "fields": {
+            "name": "Lajolla",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 398
+    },
+    {
+        "fields": {
+            "name": "Los Gatos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 399
+    },
+    {
+        "fields": {
+            "name": "Rancho Sante Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 400
+    },
+    {
+        "fields": {
+            "name": "Mc Lean",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 401
+    },
+    {
+        "fields": {
+            "name": "Mammoth Lakes",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 402
+    },
+    {
+        "fields": {
+            "name": "Thousand Oaks",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 403
+    },
+    {
+        "fields": {
+            "name": "Edina",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 404
+    },
+    {
+        "fields": {
+            "name": "Port St Lucie",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 405
+    },
+    {
+        "fields": {
+            "name": "Morrison",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 406
+    },
+    {
+        "fields": {
+            "name": "Moraga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 407
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "VT",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 408
+    },
+    {
+        "fields": {
+            "name": "Lyndon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 409
+    },
+    {
+        "fields": {
+            "name": "Old Lyme",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 410
+    },
+    {
+        "fields": {
+            "name": "Corte Madera",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 411
+    },
+    {
+        "fields": {
+            "name": "Carlsbad",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 412
+    },
+    {
+        "fields": {
+            "name": "Los Ayeles",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 413
+    },
+    {
+        "fields": {
+            "name": "Tucson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 414
+    },
+    {
+        "fields": {
+            "name": "Fitchburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 415
+    },
+    {
+        "fields": {
+            "name": "Arroyo Grande",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 416
+    },
+    {
+        "fields": {
+            "name": "Turlock",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 417
+    },
+    {
+        "fields": {
+            "name": "Bakersfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 418
+    },
+    {
+        "fields": {
+            "name": "Wasco",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 419
+    },
+    {
+        "fields": {
+            "name": "Dixon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 420
+    },
+    {
+        "fields": {
+            "name": "Stockton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 421
+    },
+    {
+        "fields": {
+            "name": "Mariposa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 422
+    },
+    {
+        "fields": {
+            "name": "Shafter",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 423
+    },
+    {
+        "fields": {
+            "name": "Inglewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 424
+    },
+    {
+        "fields": {
+            "name": "Boulevard",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 425
+    },
+    {
+        "fields": {
+            "name": "Mount Laguna",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 426
+    },
+    {
+        "fields": {
+            "name": "Aguanga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 427
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "BC",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 428
+    },
+    {
+        "fields": {
+            "name": "Burnaby",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 429
+    },
+    {
+        "fields": {
+            "name": "Pauma Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 430
+    },
+    {
+        "fields": {
+            "name": "Anza",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 431
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "DE",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 432
+    },
+    {
+        "fields": {
+            "name": "Wilmington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 433
+    },
+    {
+        "fields": {
+            "name": "Pleasantville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 434
+    },
+    {
+        "fields": {
+            "name": "Jacksonville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 435
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "NJ",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 436
+    },
+    {
+        "fields": {
+            "name": "Egg Harbor Township",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 437
+    },
+    {
+        "fields": {
+            "name": "Medford",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 438
+    },
+    {
+        "fields": {
+            "name": "Chevy Chase",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 439
+    },
+    {
+        "fields": {
+            "name": "Media",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 440
+    },
+    {
+        "fields": {
+            "name": "Jonesville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 441
+    },
+    {
+        "fields": {
+            "name": "Voctorville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 442
+    },
+    {
+        "fields": {
+            "name": "Tuxedo Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 443
+    },
+    {
+        "fields": {
+            "name": "Point Pleasant",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 444
+    },
+    {
+        "fields": {
+            "name": "Winnemucca",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 445
+    },
+    {
+        "fields": {
+            "name": "Victorville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 446
+    },
+    {
+        "fields": {
+            "name": "Naperville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 447
+    },
+    {
+        "fields": {
+            "name": "Minneapolis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 448
+    },
+    {
+        "fields": {
+            "name": "Simpsonville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 449
+    },
+    {
+        "fields": {
+            "name": "Idyllwild",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 450
+    },
+    {
+        "fields": {
+            "name": "Playa Vista",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 451
+    },
+    {
+        "fields": {
+            "name": "Compton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 452
+    },
+    {
+        "fields": {
+            "name": "Headlesburh",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 453
+    },
+    {
+        "fields": {
+            "name": "Jmul",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 454
+    },
+    {
+        "fields": {
+            "name": "San Fernando",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 455
+    },
+    {
+        "fields": {
+            "name": "West Bloonfiels",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 456
+    },
+    {
+        "fields": {
+            "name": "Miami",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 457
+    },
+    {
+        "fields": {
+            "name": "Walla Walla",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 458
+    },
+    {
+        "fields": {
+            "name": "Simi Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 459
+    },
+    {
+        "fields": {
+            "name": "Westlake Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 460
+    },
+    {
+        "fields": {
+            "name": "Fresno",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 461
+    },
+    {
+        "fields": {
+            "name": "Austin",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 462
+    },
+    {
+        "fields": {
+            "name": "Ocean Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 463
+    },
+    {
+        "fields": {
+            "name": "Gladewater",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 464
+    },
+    {
+        "fields": {
+            "name": "Doral",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 465
+    },
+    {
+        "fields": {
+            "name": "Villa Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 466
+    },
+    {
+        "fields": {
+            "name": "Blue Bell",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 467
+    },
+    {
+        "fields": {
+            "name": "Mount Kisco",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 468
+    },
+    {
+        "fields": {
+            "name": "Wilton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 469
+    },
+    {
+        "fields": {
+            "name": "Coeur D Alene",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 470
+    },
+    {
+        "fields": {
+            "name": "West Linn",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 471
+    },
+    {
+        "fields": {
+            "name": "Stevenson Ranch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 472
+    },
+    {
+        "fields": {
+            "name": "Chino Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 473
+    },
+    {
+        "fields": {
+            "name": "Waban",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 474
+    },
+    {
+        "fields": {
+            "name": "Cave Creek",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 475
+    },
+    {
+        "fields": {
+            "name": "San Luis Obispo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 476
+    },
+    {
+        "fields": {
+            "name": "Port Chester",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 477
+    },
+    {
+        "fields": {
+            "name": "Palmetto Bay",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 478
+    },
+    {
+        "fields": {
+            "name": "Tyler",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 479
+    },
+    {
+        "fields": {
+            "name": "Glen Rock",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 480
+    },
+    {
+        "fields": {
+            "name": "Dayton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 481
+    },
+    {
+        "fields": {
+            "name": "Georgetown",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 482
+    },
+    {
+        "fields": {
+            "name": "Pacific Grove",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 483
+    },
+    {
+        "fields": {
+            "name": "Chatsworth",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 484
+    },
+    {
+        "fields": {
+            "name": "La Crescenta",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 485
+    },
+    {
+        "fields": {
+            "name": "Fountain Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 486
+    },
+    {
+        "fields": {
+            "name": "Foothill Ranch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 487
+    },
+    {
+        "fields": {
+            "name": "Pahrump",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 488
+    },
+    {
+        "fields": {
+            "name": "Santa Clarita",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 489
+    },
+    {
+        "fields": {
+            "name": "Saint Helena",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 490
+    },
+    {
+        "fields": {
+            "name": "St Joseph",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 491
+    },
+    {
+        "fields": {
+            "name": "Antioch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 492
+    },
+    {
+        "fields": {
+            "name": "Piedmont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 493
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "MT",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 494
+    },
+    {
+        "fields": {
+            "name": "Bozeman",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 495
+    },
+    {
+        "fields": {
+            "name": "Daly City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 496
+    },
+    {
+        "fields": {
+            "name": "Fairfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 497
+    },
+    {
+        "fields": {
+            "name": "Pinole",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 498
+    },
+    {
+        "fields": {
+            "name": "Castro Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 499
+    },
+    {
+        "fields": {
+            "name": "Fremont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 500
+    },
+    {
+        "fields": {
+            "name": "Point Richmond",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 501
+    },
+    {
+        "fields": {
+            "name": "Hercules",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 502
+    },
+    {
+        "fields": {
+            "name": "Emeryville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 503
+    },
+    {
+        "fields": {
+            "name": "Galt",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 504
+    },
+    {
+        "fields": {
+            "name": "Davie",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 505
+    },
+    {
+        "fields": {
+            "name": "West Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 506
+    },
+    {
+        "fields": {
+            "name": "Walnut Creek",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 507
+    },
+    {
+        "fields": {
+            "name": "Santa Rosa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 508
+    },
+    {
+        "fields": {
+            "name": "El Sobrante",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 509
+    },
+    {
+        "fields": {
+            "name": "Dublin",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 510
+    },
+    {
+        "fields": {
+            "name": "Geneva",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 511
+    },
+    {
+        "fields": {
+            "name": "Carmichael",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 512
+    },
+    {
+        "fields": {
+            "name": "Clovis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 513
+    },
+    {
+        "fields": {
+            "name": "Woodland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 514
+    },
+    {
+        "fields": {
+            "name": "Rancho Cordova",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 515
+    },
+    {
+        "fields": {
+            "name": "Beaumont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 516
+    },
+    {
+        "fields": {
+            "name": "Roseville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 517
+    },
+    {
+        "fields": {
+            "name": "Visalia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 518
+    },
+    {
+        "fields": {
+            "name": "Los Alamitos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 519
+    },
+    {
+        "fields": {
+            "name": "Sylmar",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 520
+    },
+    {
+        "fields": {
+            "name": "Hilliard",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 521
+    },
+    {
+        "fields": {
+            "name": "Auburn",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 522
+    },
+    {
+        "fields": {
+            "name": "San Bruno",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 523
+    },
+    {
+        "fields": {
+            "name": "Covina",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 524
+    },
+    {
+        "fields": {
+            "name": "Fargo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 525
+    },
+    {
+        "fields": {
+            "name": "Waxhaw",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 526
+    },
+    {
+        "fields": {
+            "name": "Hood River",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 527
+    },
+    {
+        "fields": {
+            "name": "Union City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 528
+    },
+    {
+        "fields": {
+            "name": "Pleasant Hill",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 529
+    },
+    {
+        "fields": {
+            "name": "Saint Paul",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 530
+    },
+    {
+        "fields": {
+            "name": "Pacifica",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 531
+    },
+    {
+        "fields": {
+            "name": "Sunnyvale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 532
+    },
+    {
+        "fields": {
+            "name": "Kensington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 533
+    },
+    {
+        "fields": {
+            "name": "Saratoga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 534
+    },
+    {
+        "fields": {
+            "name": "Santa Clara",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 535
+    },
+    {
+        "fields": {
+            "name": "Pittsburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 536
+    },
+    {
+        "fields": {
+            "name": "Norwalk",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 537
+    },
+    {
+        "fields": {
+            "name": "Albany",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 538
+    },
+    {
+        "fields": {
+            "name": "Hanover",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 539
+    },
+    {
+        "fields": {
+            "name": "Villa Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 540
+    },
+    {
+        "fields": {
+            "name": "Falls Church",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 541
+    },
+    {
+        "fields": {
+            "name": "Albany",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 542
+    },
+    {
+        "fields": {
+            "name": "Livermore",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 543
+    },
+    {
+        "fields": {
+            "name": "Ferndale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 544
+    },
+    {
+        "fields": {
+            "name": "Sunol",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 545
+    },
+    {
+        "fields": {
+            "name": "Daytona Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 546
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "ME",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 547
+    },
+    {
+        "fields": {
+            "name": "Portland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 548
+    },
+    {
+        "fields": {
+            "name": "Clayton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 549
+    },
+    {
+        "fields": {
+            "name": "Kelseyville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 550
+    },
+    {
+        "fields": {
+            "name": "Vallejo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 551
+    },
+    {
+        "fields": {
+            "name": "Geyserville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 552
+    },
+    {
+        "fields": {
+            "name": "Port Hueneme",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 553
+    },
+    {
+        "fields": {
+            "name": "Potomac",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 554
+    },
+    {
+        "fields": {
+            "name": "Hemet",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 555
+    },
+    {
+        "fields": {
+            "name": "Chandler",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 556
+    },
+    {
+        "fields": {
+            "name": "Tuckahoe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 557
+    },
+    {
+        "fields": {
+            "name": "Glencoe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 558
+    },
+    {
+        "fields": {
+            "name": "Bronxville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 559
+    },
+    {
+        "fields": {
+            "name": "Fairfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 560
+    },
+    {
+        "fields": {
+            "name": "Nashville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 561
+    },
+    {
+        "fields": {
+            "name": "Concord",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 562
+    },
+    {
+        "fields": {
+            "name": "Alexandria",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 563
+    },
+    {
+        "fields": {
+            "name": "Chattanooga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 564
+    },
+    {
+        "fields": {
+            "name": "University Place",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 565
+    },
+    {
+        "fields": {
+            "name": "Kentfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 566
+    },
+    {
+        "fields": {
+            "name": "Bowie",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 567
+    },
+    {
+        "fields": {
+            "name": "Modesto",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 568
+    },
+    {
+        "fields": {
+            "name": "Rodeo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 569
+    },
+    {
+        "fields": {
+            "name": "St Louis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 570
+    },
+    {
+        "fields": {
+            "name": "Brentwood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 571
+    },
+    {
+        "fields": {
+            "name": "Diablo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 572
+    },
+    {
+        "fields": {
+            "name": "Milpitas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 573
+    },
+    {
+        "fields": {
+            "name": "Peeble Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 574
+    },
+    {
+        "fields": {
+            "name": "Merced",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 575
+    },
+    {
+        "fields": {
+            "name": "Millbrae",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 576
+    },
+    {
+        "fields": {
+            "name": "Petaluma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 577
+    },
+    {
+        "fields": {
+            "name": "Tracy",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 578
+    },
+    {
+        "fields": {
+            "name": "Hamilton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 579
+    },
+    {
+        "fields": {
+            "name": "Villanova",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 580
+    },
+    {
+        "fields": {
+            "name": "Portola Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 581
+    },
+    {
+        "fields": {
+            "name": "Palatine",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 582
+    },
+    {
+        "fields": {
+            "name": "Jupiter",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 583
+    },
+    {
+        "fields": {
+            "name": "Cherry Hill",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 584
+    },
+    {
+        "fields": {
+            "name": "Los Altos Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 585
+    },
+    {
+        "fields": {
+            "name": "Boca Raton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 586
+    },
+    {
+        "fields": {
+            "name": "Montara",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 587
+    },
+    {
+        "fields": {
+            "name": "Martinez",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 588
+    },
+    {
+        "fields": {
+            "name": "Santa Cruz",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 589
+    },
+    {
+        "fields": {
+            "name": "North Highlands",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 590
+    },
+    {
+        "fields": {
+            "name": "Ross",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 591
+    },
+    {
+        "fields": {
+            "name": "San Pablo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 592
+    },
+    {
+        "fields": {
+            "name": "Scranton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 593
+    },
+    {
+        "fields": {
+            "name": "Dacula",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 594
+    },
+    {
+        "fields": {
+            "name": "Greenbrae",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 595
+    },
+    {
+        "fields": {
+            "name": "Littleton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 596
+    },
+    {
+        "fields": {
+            "name": "Oviedo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 597
+    },
+    {
+        "fields": {
+            "name": "Half Moon Bay",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 598
+    },
+    {
+        "fields": {
+            "name": "Ridgefield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 599
+    },
+    {
+        "fields": {
+            "name": "Pidemont",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 600
+    },
+    {
+        "fields": {
+            "name": "Boulder Creek",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 601
+    },
+    {
+        "fields": {
+            "name": "Nevada City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 602
+    },
+    {
+        "fields": {
+            "name": "Takoma Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 603
+    },
+    {
+        "fields": {
+            "name": "Topanga",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 604
+    },
+    {
+        "fields": {
+            "name": "Greenlaw",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 605
+    },
+    {
+        "fields": {
+            "name": "Tigard",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 606
+    },
+    {
+        "fields": {
+            "name": "Terre Linda",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 607
+    },
+    {
+        "fields": {
+            "name": "Rosendale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 608
+    },
+    {
+        "fields": {
+            "name": "Baltimore",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 609
+    },
+    {
+        "fields": {
+            "name": "Ithaca",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 610
+    },
+    {
+        "fields": {
+            "name": "Nipomo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 611
+    },
+    {
+        "fields": {
+            "name": "San Diegeo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 612
+    },
+    {
+        "fields": {
+            "name": "Oyster Bay",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 613
+    },
+    {
+        "fields": {
+            "name": "Richmon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 614
+    },
+    {
+        "fields": {
+            "name": "San Anselmo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 615
+    },
+    {
+        "fields": {
+            "name": "Ione",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 616
+    },
+    {
+        "fields": {
+            "name": "Baton Rouge",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 617
+    },
+    {
+        "fields": {
+            "name": "Victoria",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 618
+    },
+    {
+        "fields": {
+            "name": "Larkspur",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 619
+    },
+    {
+        "fields": {
+            "name": "Renfrew",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 620
+    },
+    {
+        "fields": {
+            "name": "New Work",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 621
+    },
+    {
+        "fields": {
+            "name": "Berwyn",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 622
+    },
+    {
+        "fields": {
+            "name": "Pittsburgh",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 623
+    },
+    {
+        "fields": {
+            "name": "Butler",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 624
+    },
+    {
+        "fields": {
+            "name": "Detroit",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 625
+    },
+    {
+        "fields": {
+            "name": "Bell Canyon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 626
+    },
+    {
+        "fields": {
+            "name": "Newton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 627
+    },
+    {
+        "fields": {
+            "name": "Easton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 628
+    },
+    {
+        "fields": {
+            "name": "College Station",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 629
+    },
+    {
+        "fields": {
+            "name": "Walnut Creeek",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 630
+    },
+    {
+        "fields": {
+            "name": "Carmel",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 631
+    },
+    {
+        "fields": {
+            "name": "Aptos",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 632
+    },
+    {
+        "fields": {
+            "name": "Fairfax",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 633
+    },
+    {
+        "fields": {
+            "name": "La",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 634
+    },
+    {
+        "fields": {
+            "name": "Lancaster",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 635
+    },
+    {
+        "fields": {
+            "name": "Foster City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 636
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "AL",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 639
+    },
+    {
+        "fields": {
+            "name": "Santa Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 640
+    },
+    {
+        "fields": {
+            "name": "Malvern",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 641
+    },
+    {
+        "fields": {
+            "name": "East Palo Alto",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 642
+    },
+    {
+        "fields": {
+            "name": "Santa Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 643
+    },
+    {
+        "fields": {
+            "name": "Stanford",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 644
+    },
+    {
+        "fields": {
+            "name": "Flint Hill",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 645
+    },
+    {
+        "fields": {
+            "name": "Dunn Loring",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 646
+    },
+    {
+        "fields": {
+            "name": "Campbell",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 647
+    },
+    {
+        "fields": {
+            "name": "Somerville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 648
+    },
+    {
+        "fields": {
+            "name": "Haverford",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 649
+    },
+    {
+        "fields": {
+            "name": "Arlington",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 650
+    },
+    {
+        "fields": {
+            "name": "Hawthorne",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 651
+    },
+    {
+        "fields": {
+            "name": "Pt. Richmond",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 652
+    },
+    {
+        "fields": {
+            "name": "Zelienople",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 653
+    },
+    {
+        "fields": {
+            "name": "Cumberland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 654
+    },
+    {
+        "fields": {
+            "name": "Superior",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 655
+    },
+    {
+        "fields": {
+            "name": "Lamy",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 656
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "IA",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 657
+    },
+    {
+        "fields": {
+            "name": "Leclaire",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 658
+    },
+    {
+        "fields": {
+            "name": "Olympia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 659
+    },
+    {
+        "fields": {
+            "name": "Denton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 660
+    },
+    {
+        "fields": {
+            "name": "Garnet Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 661
+    },
+    {
+        "fields": {
+            "name": "Palm Beach Gardens",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 662
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "SD",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 663
+    },
+    {
+        "fields": {
+            "name": "Sioux Falls",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 664
+    },
+    {
+        "fields": {
+            "name": "Portsmouth",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 665
+    },
+    {
+        "fields": {
+            "name": "Marina Del Ray",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 666
+    },
+    {
+        "fields": {
+            "name": "Alexandria",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 667
+    },
+    {
+        "fields": {
+            "name": "Cresskill",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 668
+    },
+    {
+        "fields": {
+            "name": "Bonita Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 669
+    },
+    {
+        "fields": {
+            "name": "Rye",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 670
+    },
+    {
+        "fields": {
+            "name": "Stevensville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 671
+    },
+    {
+        "fields": {
+            "name": "Armonk",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 672
+    },
+    {
+        "fields": {
+            "name": "Grants Pass",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 673
+    },
+    {
+        "fields": {
+            "name": "Burlingame",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 674
+    },
+    {
+        "fields": {
+            "name": "Woodside",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 675
+    },
+    {
+        "fields": {
+            "name": "Belvedere",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 676
+    },
+    {
+        "fields": {
+            "name": "Nicasio",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 677
+    },
+    {
+        "fields": {
+            "name": "Inverness",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 678
+    },
+    {
+        "fields": {
+            "name": "Bottle Creek",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 679
+    },
+    {
+        "fields": {
+            "name": "Midland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 680
+    },
+    {
+        "fields": {
+            "name": "Rockport",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 681
+    },
+    {
+        "fields": {
+            "name": "Chino",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 682
+    },
+    {
+        "fields": {
+            "name": "Columbus",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 683
+    },
+    {
+        "fields": {
+            "name": "Woodland Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 684
+    },
+    {
+        "fields": {
+            "name": "Rossmoor",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 685
+    },
+    {
+        "fields": {
+            "name": "Ocean Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 686
+    },
+    {
+        "fields": {
+            "name": "Cherry Hills Village",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 687
+    },
+    {
+        "fields": {
+            "name": "Telluride",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 688
+    },
+    {
+        "fields": {
+            "name": "Atherton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 689
+    },
+    {
+        "fields": {
+            "name": "Stevens Point",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 690
+    },
+    {
+        "fields": {
+            "name": "Eastvale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 691
+    },
+    {
+        "fields": {
+            "name": "Prescott",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 692
+    },
+    {
+        "fields": {
+            "name": "Delray Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 693
+    },
+    {
+        "fields": {
+            "name": "Borrego Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 694
+    },
+    {
+        "fields": {
+            "name": "Fort Worth",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 695
+    },
+    {
+        "fields": {
+            "name": "Tulsa",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 696
+    },
+    {
+        "fields": {
+            "name": "Parks",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 697
+    },
+    {
+        "fields": {
+            "name": "Powder Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 698
+    },
+    {
+        "fields": {
+            "name": "Cheshire",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 699
+    },
+    {
+        "fields": {
+            "name": "Ambler",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 700
+    },
+    {
+        "fields": {
+            "name": "Veblen",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 701
+    },
+    {
+        "fields": {
+            "name": "Canyon Country",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 702
+    },
+    {
+        "fields": {
+            "name": "Mc Kinney",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 703
+    },
+    {
+        "fields": {
+            "name": "Boulder City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 704
+    },
+    {
+        "fields": {
+            "name": "Newbury Park",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 705
+    },
+    {
+        "fields": {
+            "name": null,
+            "short_name": "AK",
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 706
+    },
+    {
+        "fields": {
+            "name": "Anchorage",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 707
+    },
+    {
+        "fields": {
+            "name": "Walnut",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 708
+    },
+    {
+        "fields": {
+            "name": "Leucadia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 709
+    },
+    {
+        "fields": {
+            "name": "San Dieo",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 710
+    },
+    {
+        "fields": {
+            "name": "San Diego",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 711
+    },
+    {
+        "fields": {
+            "name": "La Jolla",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 712
+    },
+    {
+        "fields": {
+            "name": "Norwalk",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 713
+    },
+    {
+        "fields": {
+            "name": "Montgomery",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 714
+    },
+    {
+        "fields": {
+            "name": "Temple Terrace",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 715
+    },
+    {
+        "fields": {
+            "name": "Missoula",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 716
+    },
+    {
+        "fields": {
+            "name": "Windemere",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 717
+    },
+    {
+        "fields": {
+            "name": "Arden",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 718
+    },
+    {
+        "fields": {
+            "name": "Liverpool",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 719
+    },
+    {
+        "fields": {
+            "name": "Sandpoint",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 720
+    },
+    {
+        "fields": {
+            "name": "Stoughton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 721
+    },
+    {
+        "fields": {
+            "name": "Solona Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 722
+    },
+    {
+        "fields": {
+            "name": "Calexico",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 723
+    },
+    {
+        "fields": {
+            "name": "Downers Grove",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 724
+    },
+    {
+        "fields": {
+            "name": "Ventura",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 725
+    },
+    {
+        "fields": {
+            "name": "Des Moines",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 726
+    },
+    {
+        "fields": {
+            "name": "Signal Hill",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 727
+    },
+    {
+        "fields": {
+            "name": "Newark",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 728
+    },
+    {
+        "fields": {
+            "name": "Los Angelas",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 729
+    },
+    {
+        "fields": {
+            "name": "Jurupa Valley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 730
+    },
+    {
+        "fields": {
+            "name": "West Palm Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 731
+    },
+    {
+        "fields": {
+            "name": "Ellicott City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 732
+    },
+    {
+        "fields": {
+            "name": "Oakhurst",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 733
+    },
+    {
+        "fields": {
+            "name": "Carson",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 734
+    },
+    {
+        "fields": {
+            "name": "Lodi",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 735
+    },
+    {
+        "fields": {
+            "name": "Wenatchee",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 736
+    },
+    {
+        "fields": {
+            "name": "Belleville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 737
+    },
+    {
+        "fields": {
+            "name": "Billerica",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 738
+    },
+    {
+        "fields": {
+            "name": "Encinita",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 739
+    },
+    {
+        "fields": {
+            "name": "North Falmouth",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 740
+    },
+    {
+        "fields": {
+            "name": "Reston",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 741
+    },
+    {
+        "fields": {
+            "name": "Bronx",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 742
+    },
+    {
+        "fields": {
+            "name": "Palm Springs",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 743
+    },
+    {
+        "fields": {
+            "name": "Deerfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 744
+    },
+    {
+        "fields": {
+            "name": "Artesia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 745
+    },
+    {
+        "fields": {
+            "name": "Tuscumbia",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 746
+    },
+    {
+        "fields": {
+            "name": "Douglaston",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 747
+    },
+    {
+        "fields": {
+            "name": "Pearland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 748
+    },
+    {
+        "fields": {
+            "name": "Morrisville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 749
+    },
+    {
+        "fields": {
+            "name": "Redmond",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 750
+    },
+    {
+        "fields": {
+            "name": "Agoura Hills",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 751
+    },
+    {
+        "fields": {
+            "name": "Marlborough",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 752
+    },
+    {
+        "fields": {
+            "name": "Yuma",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 753
+    },
+    {
+        "fields": {
+            "name": "Crystal Bay",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 754
+    },
+    {
+        "fields": {
+            "name": "Lorton",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 755
+    },
+    {
+        "fields": {
+            "name": "Cary",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 756
+    },
+    {
+        "fields": {
+            "name": "Rancho Mirage",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 757
+    },
+    {
+        "fields": {
+            "name": "St Petersburg",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 758
+    },
+    {
+        "fields": {
+            "name": "Granger",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 759
+    },
+    {
+        "fields": {
+            "name": "Avon",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 760
+    },
+    {
+        "fields": {
+            "name": "Eureka",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 761
+    },
+    {
+        "fields": {
+            "name": "Flagstaff",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 762
+    },
+    {
+        "fields": {
+            "name": "Caldwell",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 763
+    },
+    {
+        "fields": {
+            "name": "Broomfield",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 764
+    },
+    {
+        "fields": {
+            "name": "Stevensville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 765
+    },
+    {
+        "fields": {
+            "name": "El Toro",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 766
+    },
+    {
+        "fields": {
+            "name": "Universal City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 767
+    },
+    {
+        "fields": {
+            "name": "Birmingham",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 768
+    },
+    {
+        "fields": {
+            "name": "Granite Falls",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 769
+    },
+    {
+        "fields": {
+            "name": "Porter Ranch",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 770
+    },
+    {
+        "fields": {
+            "name": "Homewood",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 771
+    },
+    {
+        "fields": {
+            "name": "South Orange",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 772
+    },
+    {
+        "fields": {
+            "name": "Palos Verdes Estates",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 773
+    },
+    {
+        "fields": {
+            "name": "Granite Bay",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 774
+    },
+    {
+        "fields": {
+            "name": "Naples",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 775
+    },
+    {
+        "fields": {
+            "name": "Satellite Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 776
+    },
+    {
+        "fields": {
+            "name": "Fayetteville",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 777
+    },
+    {
+        "fields": {
+            "name": "Pompano Beach",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 778
+    },
+    {
+        "fields": {
+            "name": "Elbum",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 779
+    },
+    {
+        "fields": {
+            "name": "Helendale",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 780
+    },
+    {
+        "fields": {
+            "name": "Ca",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 781
+    },
+    {
+        "fields": {
+            "name": "Sugarland",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 782
+    },
+    {
+        "fields": {
+            "name": "Salt Lake City",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 783
+    },
+    {
+        "fields": {
+            "name": "Greeley",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 784
+    },
+    {
+        "fields": {
+            "name": "Ranco Santa Fe",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 785
+    },
+    {
+        "fields": {
+            "name": "Saint Louis",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 786
+    },
+    {
+        "fields": {
+            "name": "Centennial",
+            "short_name": null,
+            "true_model_id": null
+        },
+        "model": "locality.locality",
+        "pk": 787
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 395
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 751
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 427
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 172
+        },
+        "model": "locality.city",
+        "pk": 173
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 223
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 38
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 538
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 542
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 95
+        },
+        "model": "locality.city",
+        "pk": 96
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 563
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 383
+        },
+        "model": "locality.city",
+        "pk": 667
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 137
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 332
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 287
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 39
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 353
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 700
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 105
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 706
+        },
+        "model": "locality.city",
+        "pk": 707
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 152
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 492
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 431
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 632
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 266
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 53
+        },
+        "model": "locality.city",
+        "pk": 718
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 174
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 650
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 672
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 416
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 745
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 56
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 689
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 163
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 522
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 325
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 462
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 760
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 418
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 258
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 609
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 246
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 177
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 132
+        },
+        "model": "locality.city",
+        "pk": 617
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 142
+        },
+        "model": "locality.city",
+        "pk": 143
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 516
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 626
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 737
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 377
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 228
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 676
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 145
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 394
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 335
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 192
+        },
+        "model": "locality.city",
+        "pk": 193
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 124
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 622
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 42
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 75
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 101
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 738
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 373
+        },
+        "model": "locality.city",
+        "pk": 374
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 639
+        },
+        "model": "locality.city",
+        "pk": 768
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 322
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 467
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 334
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 586
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 99
+        },
+        "model": "locality.city",
+        "pk": 100
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 312
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 44
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 669
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 302
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 694
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 59
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 679
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 107
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 704
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 601
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 425
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 567
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 494
+        },
+        "model": "locality.city",
+        "pk": 495
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 7
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 571
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 378
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 742
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 559
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 220
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 237
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 764
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 151
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 203
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 674
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 428
+        },
+        "model": "locality.city",
+        "pk": 429
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 624
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 781
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 265
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 763
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 723
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 264
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 310
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 647
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 255
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 702
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 300
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 293
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 358
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 55
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 23
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 412
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 159
+        },
+        "model": "locality.city",
+        "pk": 160
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 631
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 512
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 734
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 53
+        },
+        "model": "locality.city",
+        "pk": 756
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 499
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 222
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 475
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 308
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 787
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 157
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 556
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 281
+        },
+        "model": "locality.city",
+        "pk": 282
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 53
+        },
+        "model": "locality.city",
+        "pk": 54
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 484
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 284
+        },
+        "model": "locality.city",
+        "pk": 564
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 584
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 687
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 90
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 699
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 439
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 19
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 682
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 473
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 72
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 251
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 199
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 549
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 513
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 85
+        },
+        "model": "locality.city",
+        "pk": 86
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 99
+        },
+        "model": "locality.city",
+        "pk": 470
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 629
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 40
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 273
+        },
+        "model": "locality.city",
+        "pk": 274
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 142
+        },
+        "model": "locality.city",
+        "pk": 683
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 452
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 562
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 155
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 262
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 32
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 411
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 357
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 277
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 65
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 524
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 668
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 318
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 754
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 257
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 547
+        },
+        "model": "locality.city",
+        "pk": 654
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 60
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 311
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 594
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 186
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 496
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 202
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 346
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 505
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 123
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 481
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 546
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 744
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 33
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 693
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 660
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 298
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 657
+        },
+        "model": "locality.city",
+        "pk": 726
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 290
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 625
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 572
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 70
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 420
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 465
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 747
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 198
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 724
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 80
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 510
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 646
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 642
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 628
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 691
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 269
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 273
+        },
+        "model": "locality.city",
+        "pk": 404
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 437
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 210
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 286
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 89
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 153
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 227
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 150
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 509
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 766
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 779
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 140
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 732
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 503
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 739
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 20
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 309
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 188
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 240
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 22
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 761
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 633
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 560
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 497
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 179
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 541
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 392
+        },
+        "model": "locality.city",
+        "pk": 525
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 777
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 544
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 415
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 762
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 645
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 487
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 215
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 695
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 636
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 333
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 486
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 359
+        },
+        "model": "locality.city",
+        "pk": 360
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 284
+        },
+        "model": "locality.city",
+        "pk": 285
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 500
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 461
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 141
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 504
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 272
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 661
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 511
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 482
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 552
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 464
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 480
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 558
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 92
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 131
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 159
+        },
+        "model": "locality.city",
+        "pk": 218
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 385
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 159
+        },
+        "model": "locality.city",
+        "pk": 759
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 774
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 53
+        },
+        "model": "locality.city",
+        "pk": 769
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 673
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 243
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 784
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 595
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 605
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 11
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 235
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 598
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 579
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 324
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 539
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 118
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 190
+        },
+        "model": "locality.city",
+        "pk": 191
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 649
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 651
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 139
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 453
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 780
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 555
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 369
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 502
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 126
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 180
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 142
+        },
+        "model": "locality.city",
+        "pk": 521
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 267
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 209
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 217
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 639
+        },
+        "model": "locality.city",
+        "pk": 771
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 172
+        },
+        "model": "locality.city",
+        "pk": 250
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 527
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 381
+        },
+        "model": "locality.city",
+        "pk": 382
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 294
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 47
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 450
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 109
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 279
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 97
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 424
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 678
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 616
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 45
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 189
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 610
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 85
+        },
+        "model": "locality.city",
+        "pk": 342
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 435
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 29
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 454
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 62
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 441
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 379
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 583
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 730
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 172
+        },
+        "model": "locality.city",
+        "pk": 270
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 172
+        },
+        "model": "locality.city",
+        "pk": 289
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 236
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 550
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 533
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 566
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 260
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 185
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 634
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 366
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 485
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 114
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 6
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 712
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 17
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 115
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 336
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 256
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 387
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 376
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 57
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 135
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 148
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 301
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 83
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 398
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 304
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 331
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 46
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 391
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 144
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 95
+        },
+        "model": "locality.city",
+        "pk": 656
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 635
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 619
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 95
+        },
+        "model": "locality.city",
+        "pk": 112
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 201
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 74
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 364
+        },
+        "model": "locality.city",
+        "pk": 371
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 657
+        },
+        "model": "locality.city",
+        "pk": 658
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 16
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 364
+        },
+        "model": "locality.city",
+        "pk": 365
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 709
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 383
+        },
+        "model": "locality.city",
+        "pk": 384
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 192
+        },
+        "model": "locality.city",
+        "pk": 248
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 596
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 543
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 719
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 397
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 735
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 161
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 313
+        },
+        "model": "locality.city",
+        "pk": 314
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 156
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 755
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 519
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 315
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 585
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 729
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 15
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 413
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 399
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 230
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 408
+        },
+        "model": "locality.city",
+        "pk": 409
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 288
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 641
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 402
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 348
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 263
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 666
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 50
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 422
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 752
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 588
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 13
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 703
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 401
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 438
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 440
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 355
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 147
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 575
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 226
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 88
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 457
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 130
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 680
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 352
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 576
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 372
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 573
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 343
+        },
+        "model": "locality.city",
+        "pk": 344
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 396
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 273
+        },
+        "model": "locality.city",
+        "pk": 448
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 392
+        },
+        "model": "locality.city",
+        "pk": 393
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 354
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 362
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 494
+        },
+        "model": "locality.city",
+        "pk": 716
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 568
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 587
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 127
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 714
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 292
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 407
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 406
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 749
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 468
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 426
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 91
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 146
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 43
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 361
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 447
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 775
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 284
+        },
+        "model": "locality.city",
+        "pk": 561
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 104
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 602
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 232
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 132
+        },
+        "model": "locality.city",
+        "pk": 133
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 621
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 77
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 728
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 705
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 175
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 49
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 110
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 229
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 627
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 677
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 611
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 166
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 390
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 740
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 590
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 252
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 154
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 713
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 537
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 375
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 733
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 117
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 463
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 373
+        },
+        "model": "locality.city",
+        "pk": 686
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 71
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 388
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 271
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 305
+        },
+        "model": "locality.city",
+        "pk": 306
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 410
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 659
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 181
+        },
+        "model": "locality.city",
+        "pk": 182
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 194
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 347
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 27
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 283
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 184
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 597
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 106
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 613
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 234
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 483
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 238
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 531
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 488
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 582
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 662
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 214
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 743
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 478
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 200
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 195
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 773
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 113
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 119
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 328
+        },
+        "model": "locality.city",
+        "pk": 329
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 697
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 78
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 430
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 748
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 574
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 341
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 577
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 326
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 321
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 600
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 493
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 498
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 536
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 623
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 296
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 276
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 451
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 529
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 241
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 434
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 444
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 501
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 323
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 778
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 477
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 553
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 128
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 405
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 770
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 320
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 547
+        },
+        "model": "locality.city",
+        "pk": 548
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 581
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 381
+        },
+        "model": "locality.city",
+        "pk": 665
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 554
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 26
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 698
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 692
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 652
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 316
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 64
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 515
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 278
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 757
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 24
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 370
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 400
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 785
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 253
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 356
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 337
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 750
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 297
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 125
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 620
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 221
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 741
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 614
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 299
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 167
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 599
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 25
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 136
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 681
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 138
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 569
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 608
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 517
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 591
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 685
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 165
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 254
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 670
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 233
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 14
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 490
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 786
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 273
+        },
+        "model": "locality.city",
+        "pk": 530
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 328
+        },
+        "model": "locality.city",
+        "pk": 783
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 386
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 615
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 212
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 363
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 523
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 350
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 93
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 612
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 711
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 710
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 455
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 9
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 178
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 225
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 196
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 204
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 476
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 34
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 247
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 120
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 592
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 351
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 295
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 21
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 239
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 207
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 99
+        },
+        "model": "locality.city",
+        "pk": 720
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 134
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 224
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 535
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 489
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 589
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 639
+        },
+        "model": "locality.city",
+        "pk": 640
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 95
+        },
+        "model": "locality.city",
+        "pk": 643
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 327
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 108
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 349
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 389
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 508
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 81
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 534
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 776
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 249
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 330
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 211
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 593
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 368
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 168
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 423
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 205
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 727
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 307
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 459
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 190
+        },
+        "model": "locality.city",
+        "pk": 449
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 169
+        },
+        "model": "locality.city",
+        "pk": 170
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 663
+        },
+        "model": "locality.city",
+        "pk": 664
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 216
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 8
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 171
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 722
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 648
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 340
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 436
+        },
+        "model": "locality.city",
+        "pk": 772
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 98
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 37
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 190
+        },
+        "model": "locality.city",
+        "pk": 317
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 367
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 35
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 303
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 491
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 570
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 758
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 66
+        },
+        "model": "locality.city",
+        "pk": 67
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 116
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 644
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 343
+        },
+        "model": "locality.city",
+        "pk": 690
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 472
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 494
+        },
+        "model": "locality.city",
+        "pk": 765
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 671
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 421
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 721
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 129
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 782
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 532
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 545
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 655
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 162
+        },
+        "model": "locality.city",
+        "pk": 268
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 520
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 103
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 41
+        },
+        "model": "locality.city",
+        "pk": 603
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 121
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 345
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 10
+        },
+        "model": "locality.city",
+        "pk": 688
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 28
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 259
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 715
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 607
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 380
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 403
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 261
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 606
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 604
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 187
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 164
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 280
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 578
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 557
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 414
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 305
+        },
+        "model": "locality.city",
+        "pk": 696
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 417
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 639
+        },
+        "model": "locality.city",
+        "pk": 746
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 84
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 76
+        },
+        "model": "locality.city",
+        "pk": 443
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 479
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 528
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 767
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 565
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 30
+        },
+        "model": "locality.city",
+        "pk": 31
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 244
+        },
+        "model": "locality.city",
+        "pk": 245
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 158
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 339
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 551
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 63
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 219
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 213
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 663
+        },
+        "model": "locality.city",
+        "pk": 701
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 242
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 725
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 79
+        },
+        "model": "locality.city",
+        "pk": 618
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 446
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 111
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 466
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 18
+        },
+        "model": "locality.city",
+        "pk": 540
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 580
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 94
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 518
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 36
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 442
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 474
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 458
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 708
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 630
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 507
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 338
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 419
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 51
+        },
+        "model": "locality.city",
+        "pk": 52
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 53
+        },
+        "model": "locality.city",
+        "pk": 526
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 102
+        },
+        "model": "locality.city",
+        "pk": 736
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 12
+        },
+        "model": "locality.city",
+        "pk": 456
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 506
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 208
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 319
+        },
+        "model": "locality.city",
+        "pk": 471
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 731
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 149
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 460
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 122
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 48
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 68
+        },
+        "model": "locality.city",
+        "pk": 69
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 206
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 432
+        },
+        "model": "locality.city",
+        "pk": 433
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 85
+        },
+        "model": "locality.city",
+        "pk": 291
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 231
+        },
+        "model": "locality.city",
+        "pk": 469
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 197
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 717
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 73
+        },
+        "model": "locality.city",
+        "pk": 445
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 87
+        },
+        "model": "locality.city",
+        "pk": 183
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 514
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 684
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 675
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 58
+        },
+        "model": "locality.city",
+        "pk": 275
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 82
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 1
+        },
+        "model": "locality.city",
+        "pk": 176
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 4
+        },
+        "model": "locality.city",
+        "pk": 753
+    },
+    {
+        "fields": {
+            "county": null,
+            "fips_id": null,
+            "state": 61
+        },
+        "model": "locality.city",
+        "pk": 653
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 359
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 706
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 639
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 192
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 428
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 10
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 231
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 51
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 432
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 87
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 162
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 172
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 657
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 99
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 18
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 159
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 364
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 383
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 132
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 58
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 41
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 547
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 12
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 273
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 66
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 373
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 494
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 53
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 392
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 181
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 381
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 436
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 95
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 73
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 76
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 142
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 305
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 319
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 61
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 190
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 663
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 284
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 79
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 313
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 30
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 328
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 68
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 408
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 102
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 343
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 281
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 85
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 169
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 244
+    },
+    {
+        "fields": {
+            "fips_id": null
+        },
+        "model": "locality.state",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92101",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92121",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92019",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85054",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92037",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92103",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 6
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92109",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 7
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92123",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 8
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92821",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 9
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92119",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 10
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92075",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 11
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94105",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 12
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92104",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 13
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80111",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 14
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92128",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 15
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92111",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 16
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92116",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 17
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "48854",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 18
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92110",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 19
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92113",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 20
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95814",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 21
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92102",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 22
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90020",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 23
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91945",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 24
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91942",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 25
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92127",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 26
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60611",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 27
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92154",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 28
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92024",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 29
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94104",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 30
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92106",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 31
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92130",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 32
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94583",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 33
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92026",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 34
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92139",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 35
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92009",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 36
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92067",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 37
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92029",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 38
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92008",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 39
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92020",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 40
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92108",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 41
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92122",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 42
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92501",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 43
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92064",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 44
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92025",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 45
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92129",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 46
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92131",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 47
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91941",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 48
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92869",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 49
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92591",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 50
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92114",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 51
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92115",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 52
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92107",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 53
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91935",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 54
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "00000",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 55
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92118",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 56
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92117",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 57
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92124",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 58
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92021",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 59
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92014",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 60
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92120",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 61
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92069",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 62
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91977",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 63
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92126",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 64
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92084",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 65
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92011",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 66
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94080",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 67
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94507",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 68
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91901",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 69
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80907",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 70
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20816",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 71
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92562",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 72
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92091",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 73
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95821",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 74
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91902",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 75
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92603",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 76
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92040",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 77
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92614",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 78
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92648",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 79
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92595",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 80
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92661",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 81
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92081",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 82
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94111",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 83
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90292",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 84
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92663",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 85
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92078",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 86
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20005",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 87
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "28277",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 88
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92007",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 89
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "81611",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 90
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92105",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 91
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92694",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 92
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02108",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 93
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95014",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 94
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "15909",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 95
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92082",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 96
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92065",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 97
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91978",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 98
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96022",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 99
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "63105",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 100
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23185",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 101
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91765",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 102
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92058",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 103
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91910",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 104
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91913",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 105
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89117",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 106
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92057",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 107
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90210",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 108
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92054",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 109
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10019",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 110
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91914",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 111
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91911",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 112
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91104",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 113
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91915",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 114
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78619",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 115
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92071",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 116
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92886",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 117
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92677",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 118
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92010",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 119
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92780",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 120
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "82414",
+            "state": 85
+        },
+        "model": "locality.zipcode",
+        "pk": 121
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32952",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 122
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92056",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 123
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95864",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 124
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95762",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 125
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23323",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 126
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92561",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 127
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91203",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 128
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95831",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 129
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92673",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 130
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92660",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 131
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23457",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 132
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87123",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 133
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92201",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 134
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91030",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 135
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83714",
+            "state": 99
+        },
+        "model": "locality.zipcode",
+        "pk": 136
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92315",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 137
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92027",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 138
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98407",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 139
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91950",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 140
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92807",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 141
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90025",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 142
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93030",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 143
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80304",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 144
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92093",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 145
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93454",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 146
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91932",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 147
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92657",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 148
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23322",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 149
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20007",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 150
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90064",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 151
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60614",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 152
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90211",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 153
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91103",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 154
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22180",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 155
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20003",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 156
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "88011",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 157
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94114",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 158
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95819",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 159
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85013",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 160
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85253",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 161
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90061",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 162
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95833",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 163
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94117",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 164
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90631",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 165
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94107",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 166
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90638",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 167
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92801",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 168
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22554",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 169
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90041",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 170
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94618",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 171
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "17109",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 172
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95835",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 173
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91105",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 174
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90048",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 175
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20016",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 176
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90723",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 177
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94402",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 178
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33626",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 179
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90606",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 180
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95618",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 181
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90043",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 182
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94707",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 183
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94061",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 184
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90254",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 185
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95815",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 186
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89108",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 187
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90640",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 188
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94127",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 189
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34986",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 190
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90209",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 191
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95822",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 192
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91604",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 193
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92018",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 194
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90036",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 195
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33141",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 196
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92867",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 197
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94158",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 198
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93116",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 199
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95818",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 200
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92805",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 201
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "70163",
+            "state": 132
+        },
+        "model": "locality.zipcode",
+        "pk": 202
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92705",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 203
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92170",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 204
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94549",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 205
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94611",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 206
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "61201",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 207
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91801",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 208
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20852",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 209
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94129",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 210
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94542",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 211
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90011",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 212
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95758",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 213
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90045",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 214
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92804",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 215
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92831",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 216
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90004",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 217
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "44122",
+            "state": 142
+        },
+        "model": "locality.zipcode",
+        "pk": 218
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90713",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 219
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92166",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 220
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94920",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 221
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94043",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 222
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92138",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 223
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91106",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 224
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94025",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 225
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92701",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 226
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92651",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 227
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94110",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 228
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20004",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 229
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92192",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 230
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95691",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 231
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95817",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 232
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90245",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 233
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90013",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 234
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20036",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 235
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90622",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 236
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21401",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 237
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90057",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 238
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94612",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 239
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20006",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 240
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20001",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 241
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94609",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 242
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91731",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 243
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89031",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 244
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10003",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 245
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92882",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 246
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92612",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 247
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90806",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 248
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90059",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 249
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90703",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 250
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95687",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 251
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90621",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 252
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92083",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 253
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "46032",
+            "state": 159
+        },
+        "model": "locality.zipcode",
+        "pk": 254
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92176",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 255
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95811",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 256
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60148",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 257
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94819",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 258
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30306",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 259
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02114",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 260
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92679",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 261
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91912",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 262
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30076",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 263
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90040",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 264
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92806",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 265
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23513",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 266
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94804",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 267
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98144",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 268
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95816",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 269
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90005",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 270
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "18985",
+            "state": 169
+        },
+        "model": "locality.zipcode",
+        "pk": 271
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96701",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 272
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90023",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 273
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22202",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 274
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98056",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 275
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92284",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 276
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22181",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 277
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60010",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 278
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91776",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 279
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92028",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 280
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20171",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 281
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "68145",
+            "state": 181
+        },
+        "model": "locality.zipcode",
+        "pk": 282
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10022",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 283
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32789",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 284
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32806",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 285
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34744",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 286
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32833",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 287
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34741",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 288
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75201",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 289
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90501",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 290
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89118",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 291
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75062",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 292
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60603",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 293
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "29550",
+            "state": 190
+        },
+        "model": "locality.zipcode",
+        "pk": 294
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "72716",
+            "state": 192
+        },
+        "model": "locality.zipcode",
+        "pk": 295
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90071",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 296
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91764",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 297
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92060",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 298
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92590",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 299
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92675",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 300
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92596",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 301
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94301",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 302
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89158",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 303
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92038",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 304
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94123",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 305
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89135",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 306
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23321",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 307
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89169",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 308
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89158",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 309
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92629",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 310
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89107",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 311
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91505",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 312
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94577",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 313
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92163",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 314
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90212",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 315
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91908",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 316
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91403",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 317
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95490",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 318
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92173",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 319
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90069",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 320
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33024",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 321
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92243",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 322
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85255",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 323
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20017",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 324
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78216",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 325
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91803",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 326
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92649",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 327
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90015",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 328
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20009",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 329
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91405",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 330
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10034",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 331
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92255",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 332
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92039",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 333
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33317",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 334
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92602",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 335
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22207",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 336
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92167",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 337
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90012",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 338
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95683",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 339
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93033",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 340
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90001",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 341
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92250",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 342
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91101",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 343
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "46526",
+            "state": 159
+        },
+        "model": "locality.zipcode",
+        "pk": 344
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90620",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 345
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91607",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 346
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02446",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 347
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90019",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 348
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94610",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 349
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98122",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 350
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90067",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 351
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20037",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 352
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91761",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 353
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91335",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 354
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92234",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 355
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92706",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 356
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90049",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 357
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94501",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 358
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93101",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 359
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95106",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 360
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98040",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 361
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22760",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 362
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94002",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 363
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98101",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 364
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23324",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 365
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94608",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 366
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23607",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 367
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92356",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 368
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "Unknown-Zip",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 369
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06840",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 370
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94109",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 371
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92017",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 372
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85260",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 373
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06437",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 374
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "64113",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 375
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11218",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 376
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90272",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 377
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34223",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 378
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94566",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 379
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92013",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 380
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90291",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 381
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95945",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 382
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92171",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 383
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "00000",
+            "state": 244
+        },
+        "model": "locality.zipcode",
+        "pk": 384
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91108",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 385
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "72223",
+            "state": 192
+        },
+        "model": "locality.zipcode",
+        "pk": 386
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94965",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 387
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96819",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 388
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96814",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 389
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91711",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 390
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92646",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 391
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96821",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 392
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02119",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 393
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91906",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 394
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92253",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 395
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90232",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 396
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30107",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 397
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92672",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 398
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91202",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 399
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95949",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 400
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98103",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 401
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85281",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 402
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60047",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 403
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92625",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 404
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30068",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 405
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93011",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 406
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90039",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 407
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91302",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 408
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91006",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 409
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75230",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 410
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94010",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 411
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92835",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 412
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30024",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 413
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "31024",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 414
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96732",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 415
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94582",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 416
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93023",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 417
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90248",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 418
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "55421",
+            "state": 273
+        },
+        "model": "locality.zipcode",
+        "pk": 419
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02675",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 420
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92808",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 421
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92155",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 422
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75205",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 423
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75214",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 424
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91730",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 425
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89451",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 426
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92671",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 427
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "25314",
+            "state": 281
+        },
+        "model": "locality.zipcode",
+        "pk": 428
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94563",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 429
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20002",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 430
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "37067",
+            "state": 284
+        },
+        "model": "locality.zipcode",
+        "pk": 431
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94530",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 432
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89119",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 433
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30004",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 434
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94545",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 435
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90265",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 436
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96734",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 437
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96822",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 438
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92782",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 439
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96813",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 440
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91916",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 441
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83014",
+            "state": 85
+        },
+        "model": "locality.zipcode",
+        "pk": 442
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80132",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 443
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95124",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 444
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92624",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 445
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77069",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 446
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94903",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 447
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92870",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 448
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89102",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 449
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90277",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 450
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80246",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 451
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20814",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 452
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23227",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 453
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92587",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 454
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96825",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 455
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89169",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 456
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96815",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 457
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92653",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 458
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92003",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 459
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "62704",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 460
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90010",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 461
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91903",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 462
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85048",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 463
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60045",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 464
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "73112",
+            "state": 305
+        },
+        "model": "locality.zipcode",
+        "pk": 465
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92210",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 466
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92134",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 467
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20901",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 468
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11516",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 469
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92164",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 470
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89106",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 471
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91436",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 472
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02140",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 473
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90630",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 474
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60440",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 475
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91411",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 476
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "N1 4DJ",
+            "state": 313
+        },
+        "model": "locality.zipcode",
+        "pk": 477
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02142",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 478
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94022",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 479
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22134",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 480
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "29307",
+            "state": 190
+        },
+        "model": "locality.zipcode",
+        "pk": 481
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22932",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 482
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97217",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 483
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90660",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 484
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92507",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 485
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92316",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 486
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95131",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 487
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91768",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 488
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21076",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 489
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80013",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 490
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80237",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 491
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19103",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 492
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90670",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 493
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92211",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 494
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "84098",
+            "state": 328
+        },
+        "model": "locality.zipcode",
+        "pk": 495
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60173",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 496
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92630",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 497
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92656",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 498
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85268",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 499
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "64014",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 500
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94588",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 501
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94510",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 502
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77027",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 503
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80303",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 504
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90623",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 505
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92399",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 506
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95834",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 507
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02451",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 508
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94118",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 509
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91355",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 510
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95467",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 511
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93012",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 512
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92570",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 513
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33316",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 514
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83001",
+            "state": 85
+        },
+        "model": "locality.zipcode",
+        "pk": 515
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92563",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 516
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "53212",
+            "state": 343
+        },
+        "model": "locality.zipcode",
+        "pk": 517
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95841",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 518
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90034",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 519
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91356",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 520
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91316",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 521
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11205",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 522
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94526",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 523
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85623",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 524
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90266",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 525
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90402",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 526
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94070",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 527
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90731",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 528
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94941",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 529
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80212",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 530
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90405",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 531
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91001",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 532
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92506",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 533
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91944",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 534
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92868",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 535
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91752",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 536
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92880",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 537
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92585",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 538
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90017",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 539
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75240",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 540
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96001",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 541
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92626",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 542
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94108",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 543
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95826",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 544
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92707",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 545
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92618",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 546
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32819",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 547
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90807",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 548
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75015",
+            "state": 359
+        },
+        "model": "locality.zipcode",
+        "pk": 549
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77019",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 550
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94131",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 551
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94558",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 552
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85018",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 553
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92606",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 554
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90803",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 555
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92692",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 556
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92408",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 557
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "66219",
+            "state": 364
+        },
+        "model": "locality.zipcode",
+        "pk": 558
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85027",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 559
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95476",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 560
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91011",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 561
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "99223",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 562
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90740",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 563
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80906",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 564
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89014",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 565
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92688",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 566
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85284",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 567
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "66209",
+            "state": 364
+        },
+        "model": "locality.zipcode",
+        "pk": 568
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02054",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 569
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "39530",
+            "state": 373
+        },
+        "model": "locality.zipcode",
+        "pk": 570
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94947",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 571
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90706",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 572
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02135",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 573
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32832",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 574
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23452",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 575
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85266",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 576
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92036",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 577
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90024",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 578
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77098",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 579
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85024",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 580
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91601",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 581
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06277",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 582
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "03229",
+            "state": 381
+        },
+        "model": "locality.zipcode",
+        "pk": 583
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90027",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 584
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90068",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 585
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "40502",
+            "state": 383
+        },
+        "model": "locality.zipcode",
+        "pk": 586
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91344",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 587
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98126",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 588
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98074",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 589
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91750",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 590
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90042",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 591
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21113",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 592
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93060",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 593
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20010",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 594
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80228",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 595
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11238",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 596
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94805",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 597
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "58704",
+            "state": 392
+        },
+        "model": "locality.zipcode",
+        "pk": 598
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92175",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 599
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97701",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 600
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "79606",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 601
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "76067",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 602
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77006",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 603
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92307",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 604
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95829",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 605
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95032",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 606
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90260",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 607
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33647",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 608
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22102",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 609
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33609",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 610
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93546",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 611
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33615",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 612
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91362",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 613
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "55416",
+            "state": 273
+        },
+        "model": "locality.zipcode",
+        "pk": 614
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80465",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 615
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92592",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 616
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94556",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 617
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19104",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 618
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "05849",
+            "state": 408
+        },
+        "model": "locality.zipcode",
+        "pk": 619
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06371",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 620
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94925",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 621
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94122",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 622
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92009",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 623
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80302",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 624
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94065",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 625
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85742",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 626
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "01420",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 627
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93420",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 628
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95382",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 629
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78207",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 630
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90601",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 631
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93304",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 632
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93280",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 633
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93311",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 634
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95620",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 635
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95219",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 636
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95338",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 637
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94506",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 638
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77077",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 639
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95202",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 640
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77009",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 641
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93263",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 642
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92627",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 643
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90301",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 644
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91905",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 645
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92112",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 646
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93308",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 647
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96839",
+            "state": 172
+        },
+        "model": "locality.zipcode",
+        "pk": 648
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91948",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 649
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78228",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 650
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92023",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 651
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92536",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 652
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94116",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 653
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94103",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 654
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "V5C 3B8",
+            "state": 428
+        },
+        "model": "locality.zipcode",
+        "pk": 655
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92059",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 656
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92061",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 657
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10027",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 658
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11201",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 659
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92539",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 660
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94607",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 661
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93109",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 662
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19805",
+            "state": 432
+        },
+        "model": "locality.zipcode",
+        "pk": 663
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10570",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 664
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98102",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 665
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32205",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 666
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95757",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 667
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "8234",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 668
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "2155",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 669
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23235",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 670
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85016",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 671
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20815",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 672
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10023",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 673
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19063",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 674
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "49250",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 675
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93292",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 676
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10987",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 677
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "08742",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 678
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89445",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 679
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90230",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 680
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91423",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 681
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89052",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 682
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94132",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 683
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80220",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 684
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60540",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 685
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90077",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 686
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75229",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 687
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "70124",
+            "state": 132
+        },
+        "model": "locality.zipcode",
+        "pk": 688
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30305",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 689
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95113",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 690
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "55403",
+            "state": 273
+        },
+        "model": "locality.zipcode",
+        "pk": 691
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60615",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 692
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "29681",
+            "state": 190
+        },
+        "model": "locality.zipcode",
+        "pk": 693
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60641",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 694
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91920",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 695
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92549",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 696
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10007",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 697
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90094",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 698
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96161",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 699
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90220",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 700
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95448",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 701
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93117",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 702
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91340",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 703
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "48323",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 704
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33140",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 705
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91921",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 706
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "99362",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 707
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93065",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 708
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60622",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 709
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89101",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 710
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93728",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 711
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78757",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 712
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75647",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 713
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33178",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 714
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22205",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 715
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97702",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 716
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92861",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 717
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19422",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 718
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97229",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 719
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10549",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 720
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94708",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 721
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06897",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 722
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83814",
+            "state": 99
+        },
+        "model": "locality.zipcode",
+        "pk": 723
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97068",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 724
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91381",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 725
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91709",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 726
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02468",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 727
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91107",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 728
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85331",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 729
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85254",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 730
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93401",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 731
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10028",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 732
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20011",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 733
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "SW1W8JT",
+            "state": 313
+        },
+        "model": "locality.zipcode",
+        "pk": 734
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10573",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 735
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33157",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 736
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75703",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 737
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "07452",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 738
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "08810",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 739
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10013",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 740
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90249",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 741
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78626",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 742
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94041",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 743
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93950",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 744
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92615",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 745
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94915",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 746
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91311",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 747
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91701",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 748
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91214",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 749
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92708",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 750
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92610",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 751
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89061",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 752
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91350",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 753
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93103",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 754
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94619",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 755
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90028",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 756
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94574",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 757
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "64502",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 758
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94602",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 759
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94102",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 760
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94531",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 761
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94606",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 762
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94605",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 763
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "59715",
+            "state": 494
+        },
+        "model": "locality.zipcode",
+        "pk": 764
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94014",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 765
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94706",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 766
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94621",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 767
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94115",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 768
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94705",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 769
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94534",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 770
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94564",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 771
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94603",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 772
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94552",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 773
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94555",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 774
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94546",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 775
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94801",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 776
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94547",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 777
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94702",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 778
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95632",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 779
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22201",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 780
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "3331",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 781
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95125",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 782
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94601",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 783
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91307",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 784
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94502",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 785
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94596",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 786
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95402",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 787
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95126",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 788
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94803",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 789
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94568",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 790
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60134",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 791
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95120",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 792
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95828",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 793
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95608",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 794
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93612",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 795
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95776",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 796
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92186",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 797
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95742",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 798
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95380",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 799
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92223",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 800
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95838",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 801
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95678",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 802
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93291",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 803
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90720",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 804
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91342",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 805
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95403",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 806
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "43026",
+            "state": 142
+        },
+        "model": "locality.zipcode",
+        "pk": 807
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "96101",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 808
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94134",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 809
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95603",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 810
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94066",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 811
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91724",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 812
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60618",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 813
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94578",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 814
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94709",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 815
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94604",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 816
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94806",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 817
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94949",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 818
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "58102",
+            "state": 392
+        },
+        "model": "locality.zipcode",
+        "pk": 819
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94704",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 820
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "28173",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 821
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97031",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 822
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94404",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 823
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94587",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 824
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94523",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 825
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "55117",
+            "state": 273
+        },
+        "model": "locality.zipcode",
+        "pk": 826
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94044",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 827
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94087",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 828
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94703",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 829
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94509",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 830
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95070",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 831
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95050",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 832
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94121",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 833
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94541",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 834
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94598",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 835
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94565",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 836
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94595",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 837
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06855",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 838
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60657",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 839
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90035",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 840
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23069",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 841
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95117",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 842
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60613",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 843
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60181",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 844
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94538",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 845
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22046",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 846
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "12208",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 847
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90503",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 848
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94550",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 849
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95536",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 850
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10035",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 851
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94586",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 852
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32114",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 853
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "04102",
+            "state": 547
+        },
+        "model": "locality.zipcode",
+        "pk": 854
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87107",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 855
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94517",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 856
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94901",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 857
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95451",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 858
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94591",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 859
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95441",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 860
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94710",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 861
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93044",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 862
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60626",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 863
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80218",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 864
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23507",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 865
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20854",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 866
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92544",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 867
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85286",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 868
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10707",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 869
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78704",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 870
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95232",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 871
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10708",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 872
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94536",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 873
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06825",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 874
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "37212",
+            "state": 284
+        },
+        "model": "locality.zipcode",
+        "pk": 875
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94520",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 876
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60630",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 877
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60605",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 878
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22301",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 879
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "37415",
+            "state": 284
+        },
+        "model": "locality.zipcode",
+        "pk": 880
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98467",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 881
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60654",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 882
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22204",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 883
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85251",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 884
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30327",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 885
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94945",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 886
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94024",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 887
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94904",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 888
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94551",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 889
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20720",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 890
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94570",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 891
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95354",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 892
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94303",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 893
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94617",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 894
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94623",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 895
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94015",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 896
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94572",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 897
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94124",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 898
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "63124",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 899
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94513",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 900
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94912",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 901
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94528",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 902
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10001",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 903
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95825",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 904
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94808",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 905
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94518",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 906
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94614",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 907
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95035",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 908
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93953",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 909
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94112",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 910
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95348",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 911
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94030",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 912
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94597",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 913
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90066",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 914
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94954",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 915
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95377",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 916
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "08690",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 917
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94521",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 918
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19085",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 919
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94537",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 920
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94028",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 921
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60067",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 922
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33469",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 923
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94133",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 924
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "08003",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 925
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94306",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 926
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33431",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 927
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94579",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 928
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94037",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 929
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80211",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 930
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94539",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 931
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94553",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 932
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95061",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 933
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95409",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 934
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95660",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 935
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94957",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 936
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32801",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 937
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "18510",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 938
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30019",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 939
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80127",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 940
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32766",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 941
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95356",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 942
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95119",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 943
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94019",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 944
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98642",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 945
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94661",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 946
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95128",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 947
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95123",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 948
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95111",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 949
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95136",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 950
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95062",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 951
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93035",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 952
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94504",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 953
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94535",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 954
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95006",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 955
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95616",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 956
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95959",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 957
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20912",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 958
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32765",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 959
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90290",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 960
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11740",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 961
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97223",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 962
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "37205",
+            "state": 284
+        },
+        "model": "locality.zipcode",
+        "pk": 963
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11215",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 964
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "12472",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 965
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95304",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 966
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21210",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 967
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94590",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 968
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "14850",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 969
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93444",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 970
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94172",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 971
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11771",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 972
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10011",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 973
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93711",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 974
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94960",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 975
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97843",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 976
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "70815",
+            "state": 132
+        },
+        "model": "locality.zipcode",
+        "pk": 977
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77901",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 978
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95376",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 979
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97211",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 980
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94939",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 981
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "16053",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 982
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10026",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 983
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19312",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 984
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "15232",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 985
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "16001",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 986
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "48203",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 987
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90403",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 988
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60601",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 989
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "18040",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 990
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94533",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 991
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77840",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 992
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "17104",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 993
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93722",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 994
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22203",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 995
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93923",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 996
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95003",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 997
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94620",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 998
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94930",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 999
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93535",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1000
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87505",
+            "state": 639
+        },
+        "model": "locality.zipcode",
+        "pk": 1002
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02139",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1003
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "15228",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1004
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19355",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1005
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87501",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 1006
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94305",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1007
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "15217",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1008
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22627",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1009
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94304",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1010
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22027",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1011
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78209",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1012
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80305",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1013
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94544",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1014
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95008",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1015
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02144",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1016
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19041",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1017
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02476",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1018
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "15222",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1019
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90250",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1020
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "16101",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1021
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "04021",
+            "state": 547
+        },
+        "model": "locality.zipcode",
+        "pk": 1022
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80027",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1023
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77904",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1024
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87540",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 1025
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "52753",
+            "state": 657
+        },
+        "model": "locality.zipcode",
+        "pk": 1026
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19106",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1027
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21218",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 1028
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98506",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 1029
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77005",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1030
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95134",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1031
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "76210",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1032
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10014",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1033
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19060",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1034
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33418",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1035
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85226",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1036
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "57106",
+            "state": 663
+        },
+        "model": "locality.zipcode",
+        "pk": 1037
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "03801",
+            "state": 381
+        },
+        "model": "locality.zipcode",
+        "pk": 1038
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91387",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1039
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95132",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1040
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90058",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1041
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92887",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1042
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "41001",
+            "state": 383
+        },
+        "model": "locality.zipcode",
+        "pk": 1043
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94888",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1044
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92620",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1045
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "07626",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 1046
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20008",
+            "state": 51
+        },
+        "model": "locality.zipcode",
+        "pk": 1047
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90018",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1048
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34134",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1049
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10580",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1050
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80126",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1051
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21666",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 1052
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30315",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 1053
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10504",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1054
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97527",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 1055
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90702",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1056
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90504",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1057
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32224",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1058
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94062",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1059
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91360",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1060
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94946",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1061
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33131",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1062
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "65127",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1063
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94937",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1064
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10024",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1065
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90401",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1066
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "BWI",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1067
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78701",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1068
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "48642",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 1069
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92050",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1070
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "01966",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1071
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91708",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1072
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "43214",
+            "state": 142
+        },
+        "model": "locality.zipcode",
+        "pk": 1073
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92509",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1074
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95812",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1075
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92145",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1076
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91766",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1077
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90808",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1078
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91364",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1079
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92866",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1080
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90605",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1081
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92604",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1082
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "39564",
+            "state": 373
+        },
+        "model": "locality.zipcode",
+        "pk": 1083
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80113",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1084
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92182",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1085
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80239",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1086
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92691",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1087
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92161",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1088
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "81435",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1089
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85249",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1090
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94027",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1091
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "54481",
+            "state": 343
+        },
+        "model": "locality.zipcode",
+        "pk": 1092
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "64112",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 1093
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "86301",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1094
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89103",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1095
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75225",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1096
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33444",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1097
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92004",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1098
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "76133",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1099
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23320",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1100
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23451",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1101
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10105",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1102
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87505",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 1103
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "73116",
+            "state": 305
+        },
+        "model": "locality.zipcode",
+        "pk": 1104
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "74114",
+            "state": 305
+        },
+        "model": "locality.zipcode",
+        "pk": 1105
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33498",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1106
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "86018",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1107
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30127",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 1108
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06410",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 1109
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19002",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1110
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93010",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1111
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "57270",
+            "state": 663
+        },
+        "model": "locality.zipcode",
+        "pk": 1112
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "75071",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1113
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89005",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1114
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91320",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1115
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "99575",
+            "state": 706
+        },
+        "model": "locality.zipcode",
+        "pk": 1116
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "99515",
+            "state": 706
+        },
+        "model": "locality.zipcode",
+        "pk": 1117
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85019",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1118
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91361",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1119
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91789",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1120
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "97212",
+            "state": 319
+        },
+        "model": "locality.zipcode",
+        "pk": 1121
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80301",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1122
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92101",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1123
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92172",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1124
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92191",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1125
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92037",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1126
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10111",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1127
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92244",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1128
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92115",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1129
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90650",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1130
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92119",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1131
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92129",
+            "state": 30
+        },
+        "model": "locality.zipcode",
+        "pk": 1132
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60538",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1133
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33139",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1134
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32835",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1135
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89011",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1136
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33617",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1137
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "59808",
+            "state": 494
+        },
+        "model": "locality.zipcode",
+        "pk": 1138
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34786",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1139
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60637",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1140
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "28704",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 1141
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93704",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1142
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "13090",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1143
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78284",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1144
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80903",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1145
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98109",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 1146
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77079",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1147
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83864",
+            "state": 99
+        },
+        "model": "locality.zipcode",
+        "pk": 1148
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93105",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1149
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02072",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1150
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92016",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1151
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92232",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1152
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60515",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1153
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93004",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1154
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85050",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1155
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90603",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1156
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94051",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1157
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90046",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1158
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "46033",
+            "state": 159
+        },
+        "model": "locality.zipcode",
+        "pk": 1159
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60647",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1160
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90026",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1161
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "50309",
+            "state": 657
+        },
+        "model": "locality.zipcode",
+        "pk": 1162
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "87112",
+            "state": 95
+        },
+        "model": "locality.zipcode",
+        "pk": 1163
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10038",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1164
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90755",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1165
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "7104",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 1166
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78223",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1167
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "28205",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 1168
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33402",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1169
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "21042",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 1170
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92074",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1171
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91919",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1172
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93644",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1173
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90745",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1174
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95242",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1175
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98801",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 1176
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "48111",
+            "state": 12
+        },
+        "model": "locality.zipcode",
+        "pk": 1177
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90404",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1178
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "01821",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1179
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02556",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1180
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20191",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1181
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10463",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1182
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32120",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1183
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "02037",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1184
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91208",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1185
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92392",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1186
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92142",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1187
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92079",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1188
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92165",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1189
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19850",
+            "state": 432
+        },
+        "model": "locality.zipcode",
+        "pk": 1190
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91401",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1191
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92264",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1192
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91007",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1193
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95827",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1194
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60015",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1195
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "78720",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1196
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92593",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1197
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90701",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1198
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "35674",
+            "state": 639
+        },
+        "model": "locality.zipcode",
+        "pk": 1199
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90831",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1200
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11362",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1201
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77581",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1202
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "19067",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1203
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "11355",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1204
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77055",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1205
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93003",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1206
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "98073",
+            "state": 102
+        },
+        "model": "locality.zipcode",
+        "pk": 1207
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91301",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1208
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "01752",
+            "state": 58
+        },
+        "model": "locality.zipcode",
+        "pk": 1209
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "85364",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1210
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92802",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1211
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89402",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1212
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92879",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1213
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91354",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1214
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22079",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1215
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33487",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1216
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "37069",
+            "state": 284
+        },
+        "model": "locality.zipcode",
+        "pk": 1217
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80112",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1218
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22182",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1219
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "27519",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 1220
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "22209",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1221
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "83706",
+            "state": 99
+        },
+        "model": "locality.zipcode",
+        "pk": 1222
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92270",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1223
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90032",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1224
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33701",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1225
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "46539",
+            "state": 159
+        },
+        "model": "locality.zipcode",
+        "pk": 1226
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89109",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1227
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90038",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1228
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "17110",
+            "state": 61
+        },
+        "model": "locality.zipcode",
+        "pk": 1229
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33496",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1230
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92196",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1231
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "20817",
+            "state": 41
+        },
+        "model": "locality.zipcode",
+        "pk": 1232
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "06001",
+            "state": 231
+        },
+        "model": "locality.zipcode",
+        "pk": 1233
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95503",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1234
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "86001",
+            "state": 4
+        },
+        "model": "locality.zipcode",
+        "pk": 1235
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92169",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1236
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "07006",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 1237
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "94042",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1238
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80023",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1239
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "30319",
+            "state": 162
+        },
+        "model": "locality.zipcode",
+        "pk": 1240
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "59870",
+            "state": 494
+        },
+        "model": "locality.zipcode",
+        "pk": 1241
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "89148",
+            "state": 73
+        },
+        "model": "locality.zipcode",
+        "pk": 1242
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92262",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1243
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91608",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1244
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "35242",
+            "state": 639
+        },
+        "model": "locality.zipcode",
+        "pk": 1245
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "28630",
+            "state": 53
+        },
+        "model": "locality.zipcode",
+        "pk": 1246
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "91326",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1247
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "35209",
+            "state": 639
+        },
+        "model": "locality.zipcode",
+        "pk": 1248
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33432",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1249
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "07079",
+            "state": 436
+        },
+        "model": "locality.zipcode",
+        "pk": 1250
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "90274",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1251
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "95746",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1252
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "70117",
+            "state": 132
+        },
+        "model": "locality.zipcode",
+        "pk": 1253
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "34105",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1254
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "10002",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1255
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "23510",
+            "state": 68
+        },
+        "model": "locality.zipcode",
+        "pk": 1256
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "32937",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1257
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "13066",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1258
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "33061",
+            "state": 87
+        },
+        "model": "locality.zipcode",
+        "pk": 1259
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "13088",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1260
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "60119",
+            "state": 18
+        },
+        "model": "locality.zipcode",
+        "pk": 1261
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "13088",
+            "state": 76
+        },
+        "model": "locality.zipcode",
+        "pk": 1262
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92342",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1263
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "77487",
+            "state": 79
+        },
+        "model": "locality.zipcode",
+        "pk": 1264
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "84103",
+            "state": 328
+        },
+        "model": "locality.zipcode",
+        "pk": 1265
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80631",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1266
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92150",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1267
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "63101",
+            "state": 66
+        },
+        "model": "locality.zipcode",
+        "pk": 1268
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "80122",
+            "state": 10
+        },
+        "model": "locality.zipcode",
+        "pk": 1269
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92133",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1270
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "93744",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1271
+    },
+    {
+        "fields": {
+            "city": null,
+            "county": null,
+            "name": null,
+            "short_name": "92423",
+            "state": 1
+        },
+        "model": "locality.zipcode",
+        "pk": 1272
+    }
+]

--- a/disclosure/fixtures/2016_07_05_form.json
+++ b/disclosure/fixtures/2016_07_05_form.json
@@ -1,0 +1,42 @@
+[
+    {
+        "fields": {
+            "locality": null,
+            "name": "Form 460 Schedule A",
+            "submission_frequency": "",
+            "text_id": "460A"
+        },
+        "model": "finance.form",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "locality": null,
+            "name": "Form 460 Schedule C",
+            "submission_frequency": "",
+            "text_id": "460C"
+        },
+        "model": "finance.form",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "locality": null,
+            "name": "Form 460 Schedule D",
+            "submission_frequency": "",
+            "text_id": "460D"
+        },
+        "model": "finance.form",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "locality": null,
+            "name": "Form 497",
+            "submission_frequency": "",
+            "text_id": "F497P1"
+        },
+        "model": "finance.form",
+        "pk": 4
+    }
+]

--- a/disclosure/fixtures/2016_07_05_reporting_period.json
+++ b/disclosure/fixtures/2016_07_05_reporting_period.json
@@ -1,0 +1,98 @@
+[
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 1,
+            "locality": 2,
+            "period_end": "2016-12-31",
+            "period_start": "2016-01-01",
+            "permanent": false
+        },
+        "model": "finance.reportingperiod",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 2,
+            "locality": 2,
+            "period_end": "2016-12-31",
+            "period_start": "2016-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 3,
+            "locality": 2,
+            "period_end": "2016-12-31",
+            "period_start": "2016-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 4,
+            "locality": 2,
+            "period_end": "2016-12-31",
+            "period_start": "2016-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 4
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 1,
+            "locality": 2,
+            "period_end": "2015-12-31",
+            "period_start": "2015-01-01",
+            "permanent": false
+        },
+        "model": "finance.reportingperiod",
+        "pk": 5
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 2,
+            "locality": 2,
+            "period_end": "2015-12-31",
+            "period_start": "2015-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 6
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 3,
+            "locality": 2,
+            "period_end": "2015-12-31",
+            "period_start": "2015-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 7
+    },
+    {
+        "fields": {
+            "filing_deadline": null,
+            "form": 4,
+            "locality": 2,
+            "period_end": "2015-12-31",
+            "period_start": "2015-01-01",
+            "permanent": true
+        },
+        "model": "finance.reportingperiod",
+        "pk": 8
+    }
+]

--- a/finance/management/commands/xformnetfilerawdata.py
+++ b/finance/management/commands/xformnetfilerawdata.py
@@ -113,7 +113,7 @@ def parse_benefactor(row, verbosity=1):
 
     elif row['entity_Cd'] == 'OTH':  # Commerial benefactor or Other
         benefactor, _ = models.OtherBenefactor.objects \
-            .get_or_create(name=clean_name(row['tran_NamL']))
+            .get_or_create(name=clean_name(row.get('tran_NamL', '')))
         benefactor.benefactor_locality = bf_city
         benefactor.save()
 
@@ -603,6 +603,7 @@ def load_form_data(data, agency_fn, form_name, form_type=None,
         except Exception as ex:
             error_rows.append((ri, raw_row, minimal_row, ex))
             # TODO: Store errors, for review later.
+            print repr(raw_row)
             raise
 
     return error_rows

--- a/finance/migrations/0009_auto_20160706_0339.py
+++ b/finance/migrations/0009_auto_20160706_0339.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os.path as op
+
+from django.conf import settings
+from django.core.management import call_command
+from django.db import models, migrations
+
+
+def load_ballot_data(apps, schema_editor):
+    fixtures = (
+        ('finance', op.join(settings.FIXTURES_DIR, '2016_07_05_form.json')),
+        ('finance', op.join(settings.FIXTURES_DIR, '2016_07_05_reporting_period.json')),
+    )
+
+    for app, path in fixtures:
+        call_command('loaddata', path, app=app)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('finance', '0008_auto_20160320_2349'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reportingperiod',
+            name='permanent',
+            field=models.BooleanField(default=True, help_text='Whether data is reported once, or re-reported.'),
+        ),
+        migrations.RunPython(load_ballot_data),
+    ]

--- a/finance/tests/test_xformnetfilerawdata.py
+++ b/finance/tests/test_xformnetfilerawdata.py
@@ -24,7 +24,7 @@ class WithForm460ADataTest(TestCase):
     The default values point to a small, but relatively rich, csv.
     """
     @classmethod
-    def setUpClass(cls, test_agency='CMA', test_year='2015'):
+    def setUpClass(cls, test_agency='CSD', test_year='2015'):
         call_command('xformnetfilerawdata',
                      agencies=test_agency, years=test_year,
                      forms='A', verbosity=0)


### PR DESCRIPTION
This adds the `Forms` and `ReportingPeriods` for San Diego. The reporting periods are bogus, I just set them to Jan 1-Dec 31, but this provides all the data needed so that you can now run `python manage.py xformnetfilerawdata --year 2016 --agencies CSD` to parse San Diego data.
