### PR TITLE
Use CSD 460A data for referendum test

### DIFF
--- a/disclosure/tests/test_api_supporting_opposing.py
+++ b/disclosure/tests/test_api_supporting_opposing.py
@@ -5,7 +5,7 @@ from finance.tests.utils import with_form460A_data
 from finance.models import Beneficiary
 
 
-@with_form460A_data(test_agency='COS', test_year='2015')
+@with_form460A_data(test_agency='CSD', test_year='2015')
 class OpposingTests(APITestCase):
 
     def do_the_thing_for_candidates(self, support):


### PR DESCRIPTION
I'm not sure if this change makes any sense, but these tests were
relying on some data that didn't exist in wherever the COS data comes
from. Updating this to the CSD data makes these tests pass ¯_(ツ)_/¯
