### PR TITLE
Serialize BallotItems as their subclass

### DIFF
--- a/ballot/serializers/ballot.py
+++ b/ballot/serializers/ballot.py
@@ -1,36 +1,9 @@
 from rest_framework import serializers
-from ..models import Ballot, BallotItem, Candidate, Office, OfficeElection, Referendum
+
+from .office_election import OfficeElectionSerializer
+from .referendum import ReferendumSerializer
+from .. import models
 from _django_utils import ExtendedModelSerializer
-
-
-class CandidateSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Candidate
-
-
-class OfficeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Office
-
-
-class ReferendumSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Referendum
-        exclude = ('ballot',)
-
-
-class OfficeElectionSerializer(serializers.ModelSerializer):
-    candidates = CandidateSerializer(many=True)
-
-    class Meta:
-        model = OfficeElection
-        exclude = ('ballot', 'office')
-
-    def to_representation(self, obj):
-        office = OfficeSerializer(obj.office).data
-        office_election = super(OfficeElectionSerializer, self).to_representation(obj)
-        office.update(office_election)
-        return office
 
 
 class BallotItemSerializer(serializers.ModelSerializer):
@@ -48,7 +21,7 @@ class BallotItemSerializer(serializers.ModelSerializer):
         return subclass_data
 
     class Meta:
-        model = BallotItem
+        model = models.BallotItem
         exclude = ('ballot',)
 
 
@@ -56,5 +29,5 @@ class BallotSerializer(ExtendedModelSerializer):
     ballot_items = BallotItemSerializer(many=True, read_only=True)
 
     class Meta:
-        model = Ballot
+        model = models.Ballot
         rename = dict(locality='locality_id')

--- a/ballot/serializers/ballot.py
+++ b/ballot/serializers/ballot.py
@@ -1,18 +1,59 @@
 from rest_framework import serializers
-from ..models import Ballot, BallotItem
+from ..models import Ballot, BallotItem, Candidate, Office, OfficeElection, Referendum
 from _django_utils import ExtendedModelSerializer
 
 
-class BallotItemSerializer(ExtendedModelSerializer):
+class CandidateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Candidate
+
+
+class OfficeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Office
+
+
+class ReferendumSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Referendum
+        exclude = ('ballot',)
+
+
+class OfficeElectionSerializer(serializers.ModelSerializer):
+    candidates = CandidateSerializer(many=True)
+
+    class Meta:
+        model = OfficeElection
+        exclude = ('ballot', 'office')
+
+    def to_representation(self, obj):
+        office = OfficeSerializer(obj.office).data
+        office_election = super(OfficeElectionSerializer, self).to_representation(obj)
+        office.update(office_election)
+        return office
+
+
+class BallotItemSerializer(serializers.ModelSerializer):
     contest_type = serializers.CharField(source='get_contest_type_display')
-    name = serializers.CharField(source='__str__')
+
+    def to_representation(self, obj):
+        ballot_item = super(BallotItemSerializer, self).to_representation(obj)
+        subclass_data = dict()
+        if obj.contest_type == 'R':
+            subclass_data = ReferendumSerializer(obj.referendum).data
+        elif obj.contest_type == 'O':
+            subclass_data = OfficeElectionSerializer(obj.officeelection).data
+
+        subclass_data.update(ballot_item)
+        return subclass_data
 
     class Meta:
         model = BallotItem
+        exclude = ('ballot',)
 
 
 class BallotSerializer(ExtendedModelSerializer):
-    ballot_items = BallotItemSerializer(many=True, read_only=True, exclude=['ballot'])
+    ballot_items = BallotItemSerializer(many=True, read_only=True)
 
     class Meta:
         model = Ballot

--- a/ballot/serializers/office_election.py
+++ b/ballot/serializers/office_election.py
@@ -29,7 +29,7 @@ class OfficeElectionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.OfficeElection
-        exclude = ('ballot', 'office')
+        exclude = ('ballot', 'contest_type', 'office')
         rename = dict(locality='locality_id', ballot_item='ballot_item_id')
 
     def to_representation(self, obj):

--- a/ballot/serializers/office_election.py
+++ b/ballot/serializers/office_election.py
@@ -4,17 +4,36 @@ from .. import models
 from _django_utils.serializers import ExtendedModelSerializer
 
 
+class OfficeSerializer(serializers.ModelSerializer):
+    locality_id = serializers.PrimaryKeyRelatedField(source='locality', read_only=True)
+
+    class Meta:
+        model = models.Office
+        exclude = ('locality',)
+
+
 class CandidateSerializer(ExtendedModelSerializer):
     party = serializers.CharField(max_length=50, source='party.name')
+    ballot_item_id = serializers.PrimaryKeyRelatedField(source='ballot_item', read_only=True)
+    office_election_id = serializers.PrimaryKeyRelatedField(
+        source='office_election',
+        read_only=True)
 
     class Meta:
         model = models.Candidate
+        exclude = ('ballot_item', 'office_election')
 
 
-class OfficeElectionSerializer(ExtendedModelSerializer):
-    name = serializers.CharField(max_length=50, source='office.name')
+class OfficeElectionSerializer(serializers.ModelSerializer):
+    candidates = CandidateSerializer(many=True)
 
     class Meta:
         model = models.OfficeElection
-        exclude = ('contest_type',)
-        rename = dict(ballot='ballot_id')
+        exclude = ('ballot', 'office')
+        rename = dict(locality='locality_id', ballot_item='ballot_item_id')
+
+    def to_representation(self, obj):
+        office = OfficeSerializer(obj.office).data
+        office_election = super(OfficeElectionSerializer, self).to_representation(obj)
+        office.update(office_election)
+        return office

--- a/ballot/serializers/referendum.py
+++ b/ballot/serializers/referendum.py
@@ -1,9 +1,9 @@
+from rest_framework import serializers
+
 from .. import models
-from _django_utils.serializers import ExtendedModelSerializer
 
 
-class ReferendumSerializer(ExtendedModelSerializer):
+class ReferendumSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Referendum
-        exclude = ('contest_type',)
-        rename = dict(ballot='ballot_id')
+        exclude = ('ballot',)

--- a/ballot/serializers/referendum.py
+++ b/ballot/serializers/referendum.py
@@ -4,6 +4,8 @@ from .. import models
 
 
 class ReferendumSerializer(serializers.ModelSerializer):
+    ballot_id = serializers.PrimaryKeyRelatedField(source='ballot.id', read_only=True)
+
     class Meta:
         model = models.Referendum
         exclude = ('ballot',)

--- a/ballot/tests/factory.py
+++ b/ballot/tests/factory.py
@@ -1,5 +1,15 @@
 from __future__ import absolute_import
 import factory
+from faker import Faker
+
+faker = Faker()
+
+
+class PartyFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker('company')
+
+    class Meta:
+        model = 'ballot.Party'
 
 
 class StateFactory(factory.django.DjangoModelFactory):
@@ -37,7 +47,7 @@ class ReferendumFactory(factory.django.DjangoModelFactory):
         model = 'ballot.Referendum'
 
     number = factory.Faker('random_letter')
-    title = factory.Faker('sentences', nb=1)
+    title = factory.Faker('text', max_nb_chars=100)
     ballot = factory.SubFactory(BallotFactory)
     contest_type = 'R'
 
@@ -74,4 +84,5 @@ class CandidateFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker('first_name')
     middle_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
-    ballot_item = factory.SubFactory(OfficeElectionFactory)
+    office_election = factory.SubFactory(OfficeElectionFactory)
+    party = factory.SubFactory(PartyFactory)

--- a/ballot/tests/test_api_ballot.py
+++ b/ballot/tests/test_api_ballot.py
@@ -2,8 +2,6 @@ from django.core.urlresolvers import reverse
 
 from rest_framework.test import APITestCase
 
-from ballot.models import Ballot
-
 from . import factory
 
 
@@ -25,9 +23,11 @@ class BallotAPITest(APITestCase):
         self.assertIn('ballot_items', resp.data)
 
         # Find the first office_election
-        office_election = next(b for b in resp.data.get('ballot_items') if b['contest_type'] == 'Office')
+        office_election = next(b for b in resp.data.get('ballot_items')
+                               if b['contest_type'] == 'Office')
         # Find the first referendum
-        referendum = next(b for b in resp.data.get('ballot_items') if b['contest_type'] == 'Referendum')
+        referendum = next(b for b in resp.data.get('ballot_items')
+                          if b['contest_type'] == 'Referendum')
 
         self.assertIn('id', office_election)
         self.assertIn('name', office_election)
@@ -56,9 +56,11 @@ class BallotAPITest(APITestCase):
         self.assertIn('ballot_items', resp.data)
 
         # Find the first office_election
-        office_election = next(b for b in resp.data.get('ballot_items') if b['contest_type'] == 'Office')
+        office_election = next(b for b in resp.data.get('ballot_items')
+                               if b['contest_type'] == 'Office')
         # Find the first referendum
-        referendum = next(b for b in resp.data.get('ballot_items') if b['contest_type'] == 'Referendum')
+        referendum = next(b for b in resp.data.get('ballot_items')
+                          if b['contest_type'] == 'Referendum')
 
         self.assertIn('id', office_election)
         self.assertIn('name', office_election)

--- a/ballot/tests/test_api_office_election.py
+++ b/ballot/tests/test_api_office_election.py
@@ -2,23 +2,30 @@ from django.core.urlresolvers import reverse
 
 from rest_framework.test import APITestCase
 
-from finance.tests.utils import with_form460A_data
-from ballot.models import Candidate, OfficeElection
+from . import factory
 
 
-@with_form460A_data
 class OfficeElectionAPITest(APITestCase):
+    def setUp(self):
+        self.office_election = factory.OfficeElectionFactory()
+
+        # Create two candidates
+        factory.CandidateFactory(office_election=self.office_election)
+        factory.CandidateFactory(office_election=self.office_election)
 
     def test_office_election_with_id(self):
-        office_election = OfficeElection.objects.all()[0]
+        office_election = self.office_election
         resp = self.client.get(
             reverse('office_election_get',
                     kwargs={'office_election_id': office_election.id}))
 
-        self.assertEqual(office_election.id, resp.data['id'])
-        self.assertEqual(office_election.office.id, resp.data['office'])
-        self.assertEqual(office_election.ballot.id, resp.data['ballot_id'])
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data.get('id'), office_election.id)
+        self.assertEqual(resp.data.get('locality_id'), office_election.office.locality.id)
+        self.assertEqual(len(resp.data.get('candidates')), 2)
         self.assertNotIn('contest_type', resp.data)
+        self.assertNotIn('office', resp.data)
+        self.assertNotIn('ballot', resp.data)
 
     def test_office_election_bad_id_404(self):
         """ Unknown office election ID"""
@@ -28,19 +35,25 @@ class OfficeElectionAPITest(APITestCase):
         self.assertEqual(resp.status_code, 404)
 
 
-@with_form460A_data
 class CandidateAPITest(APITestCase):
+    def setUp(self):
+        self.candidate = factory.CandidateFactory()
 
     def test_candidate_with_id(self):
-        candidate = Candidate.objects.all()[0]
+        candidate = self.candidate
         resp = self.client.get(
             reverse('candidate_get',
                     kwargs={'candidate_id': candidate.id}))
 
-        self.assertEqual(candidate.id, resp.data['id'])
-        self.assertEqual(candidate.first_name, resp.data['first_name'])
-        self.assertEqual(candidate.last_name, resp.data['last_name'])
-        self.assertEqual(candidate.party, resp.data['party'])
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data.get('id'), candidate.id)
+        self.assertEqual(resp.data.get('first_name'), candidate.first_name)
+        self.assertEqual(resp.data.get('last_name'), candidate.last_name)
+        self.assertEqual(resp.data.get('photo_url'), candidate.photo_url)
+        self.assertEqual(resp.data.get('ballot_item_id'), candidate.office_election.id)
+        self.assertEqual(resp.data.get('office_election_id'), candidate.office_election.id)
+        self.assertIsNotNone(candidate.party.name)
+        self.assertEqual(resp.data.get('party'), candidate.party.name)
 
     def test_candidate_bad_id_404(self):
         """ Unknown candidate ID"""

--- a/ballot/tests/test_api_referendum.py
+++ b/ballot/tests/test_api_referendum.py
@@ -2,27 +2,26 @@ from django.core.urlresolvers import reverse
 
 from rest_framework.test import APITestCase
 
-from finance.tests.utils import with_form460A_data
-from ballot.models import Ballot, Referendum
+from . import factory
 
 
-@with_form460A_data
 class ReferendumAPITest(APITestCase):
+    def setUp(self):
+        self.referendum = factory.ReferendumFactory()
 
     def test_referendum_with_id(self):
-        # referendum = Referendum.objects.all()[0]
-        ballot = Ballot.objects.all()[0]
-        referendum, _ = Referendum.objects.get_or_create(
-            ballot=ballot, title='dummy', number='r123')
+        referendum = self.referendum
 
         resp = self.client.get(
             reverse('referendum_get',
                     kwargs={'referendum_id': referendum.id}))
 
-        self.assertEqual(referendum.id, resp.data['id'])
-        self.assertEqual(referendum.title, resp.data['title'])
-        self.assertEqual(referendum.number, resp.data['number'])
-        self.assertEqual(referendum.ballot.id, resp.data['ballot_id'])
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(referendum.title)
+        self.assertEqual(resp.data.get('id'), referendum.id)
+        self.assertEqual(resp.data.get('title'), referendum.title)
+        self.assertEqual(resp.data.get('number'),  referendum.number)
+        self.assertEqual(resp.data.get('ballot_id'), referendum.ballot.id)
         self.assertNotIn('ballot', resp.data)
 
     def test_referendum_bad_id_404(self):

--- a/ballot/tests/test_api_referendum.py
+++ b/ballot/tests/test_api_referendum.py
@@ -20,7 +20,7 @@ class ReferendumAPITest(APITestCase):
         self.assertIsNotNone(referendum.title)
         self.assertEqual(resp.data.get('id'), referendum.id)
         self.assertEqual(resp.data.get('title'), referendum.title)
-        self.assertEqual(resp.data.get('number'),  referendum.number)
+        self.assertEqual(resp.data.get('number'), referendum.number)
         self.assertEqual(resp.data.get('ballot_id'), referendum.ballot.id)
         self.assertNotIn('ballot', resp.data)
 

--- a/ballot/views/ballot.py
+++ b/ballot/views/ballot.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from ..models import Ballot
@@ -37,5 +38,9 @@ class CurrentBallotViewSet(BallotViewSet):
         """
         The most recent active ballot.
         """
-        ballot = get_object_or_404(Ballot, locality_id=locality_id)
+        ballot = Ballot.objects.filter(locality__id=locality_id).order_by('-date').first()
+
+        if ballot is None:
+            raise Http404('No ballots for this locality.')
+
         return Response(BallotSerializer(ballot).data)

--- a/disclosure/tests/test_api_supporting_opposing.py
+++ b/disclosure/tests/test_api_supporting_opposing.py
@@ -10,7 +10,7 @@ class SupportingOpposingCandidateTests(APITestCase):
     def setUp(self):
         self.office_election = OfficeElectionFactory()
         self.candidate = CandidateFactory(
-            ballot_item=self.office_election
+            office_election=self.office_election
         )
 
     def test_candidate_opposing_list(self):


### PR DESCRIPTION
@jnmarcus @KyleW this changes the `current_ballot` API. `Office`s and `Referendum`s will be serialized with their proper fields. You can still rely on `contest_type` to determine `Office`s from `Referendum`s. Note that while an `Office` has a `name`, `Referendum` does not, it has a `number` (which can be a letter) and a `title`. Unfortunately the DB is not populated with referendum data yet, so you'll still see things like "Prop: Unknown" in some cases. You can at least still use the `id` to get finance data and supporting/opposing committees. Here's an example:

``` json
{
    "id": 2,
    "date": "2016-11-08",
    "locality_id": 117,
    "ballot_items": [
        {
            "id": 34,
            "name": "For Mayor",
            "description": "",
            "locality_id": 117,
            "candidates": [
                {
                    "id": 47,
                    "photo_url": null,
                    "website_url": null,
                    "facebook_url": null,
                    "twitter_url": null,
                    "first_name": "Jean",
                    "middle_name": null,
                    "last_name": "Quan",
                    "ballot_item_id": 34,
                    "office_election_id": 34,
                    "party": null
                }
            ],
            "contest_type": "Office"
        },
        {
            "id": 35,
            "contest_type": "Referendum",
            "photo_url": null,
            "website_url": null,
            "facebook_url": null,
            "twitter_url": null,
            "title": "Unknown",
            "number": null
        },
// ...
```
