### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/caciviclab/disclosure-backend.png?columns=all)](https://waffle.io/caciviclab/disclosure-backend?utm_source=badge)
 [![Build
 Status](https://travis-ci.org/caciviclab/disclosure-backend.svg?branch=master)](https://travis-ci.org/caciviclab/disclosure-backend)
 [![Coverage Status](https://coveralls.io/repos/caciviclab/disclosure-backend/badge.svg?branch=master&service=github)](https://coveralls.io/github/caciviclab/disclosure-backend?branch=master)


### PR DESCRIPTION
Merge this to receive a badge indicating columns and number of cards in your columns on your waffle.io board at https://waffle.io/caciviclab/disclosure-backend

This was requested by a real person (user adborden) on waffle.io, we're not trying to spam you.